### PR TITLE
refactor to support latest etcd

### DIFF
--- a/etcd/etcdtest/client.go
+++ b/etcd/etcdtest/client.go
@@ -9,21 +9,21 @@ import (
 
 // Client represents a fake etcd client. Used for testing.
 type Client struct {
-	Responses map[string][]*etcd.Response
+	Responses map[string]*etcd.Response
 }
 
 // Get mimics the etcd.Client.Get() method.
-func (c *Client) Get(key string) ([]*etcd.Response, error) {
+func (c *Client) Get(key string, sort, recurse bool) (*etcd.Response, error) {
 	return c.Responses[key], nil
 }
 
 // AddResponses adds or updates the Client.Responses map.
-func (c *Client) AddResponse(key string, response []*etcd.Response) {
+func (c *Client) AddResponse(key string, response *etcd.Response) {
 	c.Responses[key] = response
 }
 
 // NewClient returns a fake etcd client.
 func NewClient() *Client {
-	responses := make(map[string][]*etcd.Response)
+	responses := make(map[string]*etcd.Response)
 	return &Client{responses}
 }

--- a/etcd/etcdutil/client.go
+++ b/etcd/etcdutil/client.go
@@ -6,7 +6,7 @@ package etcdutil
 import (
 	"errors"
 	"github.com/coreos/go-etcd/etcd"
-	"path/filepath"
+	"log"
 	"strings"
 )
 
@@ -17,7 +17,7 @@ var replacer = strings.NewReplacer("/", "_")
 func NewEtcdClient(machines []string, cert, key string) (*etcd.Client, error) {
 	c := etcd.NewClient(machines)
 	if cert != "" && key != "" {
-		_, err := c.SetCertAndKey(cert, key)
+		err := c.SetCertAndKey(cert, key)
 		if err != nil {
 			return c, err
 		}
@@ -30,19 +30,24 @@ func NewEtcdClient(machines []string, cert, key string) (*etcd.Client, error) {
 }
 
 type EtcdClient interface {
-	Get(key string) ([]*etcd.Response, error)
+	Get(key string, sort bool, recursive bool) (*etcd.Response, error)
 }
 
 // GetValues queries etcd for keys prefixed by prefix.
 // Etcd paths (keys) are translated into names more suitable for use in
-// templates. For example if prefix where set to '/production' and one of the
-// keys where '/nginx/port'; the prefixed '/production/nginx/port' key would
-// be quired for. If the value for the prefixed key where 80, the returned map
+// templates. For example if prefix were set to '/production' and one of the
+// keys were '/nginx/port'; the prefixed '/production/nginx/port' key would
+// be queried for. If the value for the prefixed key where 80, the returned map
 // would contain the entry vars["nginx_port"] = "80".
 func GetValues(c EtcdClient, prefix string, keys []string) (map[string]interface{}, error) {
 	vars := make(map[string]interface{})
 	for _, key := range keys {
-		err := etcdWalk(c, filepath.Join(prefix, key), prefix, vars)
+		log.Println(prefix, key)
+		resp, err := c.Get(key, false, true)
+		if err != nil {
+			return vars, err
+		}
+		err = nodeWalk(resp.Node, prefix, vars)
 		if err != nil {
 			return vars, err
 		}
@@ -50,18 +55,16 @@ func GetValues(c EtcdClient, prefix string, keys []string) (map[string]interface
 	return vars, nil
 }
 
-// etcdWalk recursively descends etcd paths, updating vars.
-func etcdWalk(c EtcdClient, key string, prefix string, vars map[string]interface{}) error {
-	values, err := c.Get(key)
-	if err != nil {
-		return err
-	}
-	for _, v := range values {
-		if !v.Dir {
-			key := pathToKey(v.Key, prefix)
-			vars[key] = v.Value
+// nodeWalk recursively descends nodes, updating vars.
+func nodeWalk(node *etcd.Node, prefix string, vars map[string]interface{}) error {
+	if node != nil {
+		if !node.Dir {
+			key := pathToKey(node.Key, prefix)
+			vars[key] = node.Value
 		} else {
-			etcdWalk(c, v.Key, prefix, vars)
+			for _, node := range node.Nodes {
+				nodeWalk(&node, prefix, vars)
+			}
 		}
 	}
 	return nil

--- a/etcd/etcdutil/client_test.go
+++ b/etcd/etcdutil/client_test.go
@@ -37,22 +37,15 @@ func TestPathToKey(t *testing.T) {
 func TestGetValues(t *testing.T) {
 	// Use stub etcd client.
 	c := etcdtest.NewClient()
-	fooResp := []*etcd.Response{
-		{Key: "/foo/one", Dir: false, Value: "one"},
-		{Key: "/foo/two", Dir: false, Value: "two"},
-		{Key: "/foo/three", Dir: true},
-	}
-	fooThreeResp := []*etcd.Response{
-		{Key: "/foo/three/bar", Dir: false, Value: "three_bar"},
-	}
-	nginxResp := []*etcd.Response{
-		{Key: "/nginx/port", Dir: false, Value: "443"},
-		{Key: "/nginx/worker_processes", Dir: false, Value: "4"},
-	}
+
+	fooResp := &etcd.Response{Action: "GET", Node: &etcd.Node{Key: "/foo", Dir: true, Value: "", Nodes: etcd.Nodes{etcd.Node{Key: "/foo/one", Dir: false, Value: "one"}, etcd.Node{Key: "foo/two", Dir: false, Value: "two"}, etcd.Node{Key: "/foo/three", Dir: true, Value: "", Nodes: etcd.Nodes{etcd.Node{Key: "/foo/three/bar", Value: "three_bar", Dir: false}}}}}}
+	quuxResp := &etcd.Response{Action: "GET", Node: &etcd.Node{Key:"/quux", Dir: false, Value: "foo"}}
+	nginxResp := &etcd.Response{Action: "GET", Node: &etcd.Node{Key: "/nginx", Value: "", Dir: true, Nodes: etcd.Nodes{etcd.Node{Key: "/nginx/port", Dir: false, Value: "443"}, etcd.Node{Key: "/nginx/worker_processes", Dir: false, Value: "4"}}}}
+
 	c.AddResponse("/foo", fooResp)
-	c.AddResponse("/foo/three", fooThreeResp)
+	c.AddResponse("/quux", quuxResp)
 	c.AddResponse("/nginx", nginxResp)
-	keys := []string{"/nginx", "/foo"}
+	keys := []string{"/nginx", "/foo", "/quux"}
 	values, err := GetValues(c, "", keys)
 	if err != nil {
 		t.Error(err.Error())
@@ -65,5 +58,8 @@ func TestGetValues(t *testing.T) {
 	}
 	if values["foo_three_bar"] != "three_bar" {
 		t.Errorf("Expected foo_three_bar == three_bar, got %s", values["foo_three_bar"])
+	}
+	if values["quux"] != "foo" {
+		t.Errorf("Expected quux == foo, got %s", values["quux"])
 	}
 }

--- a/resource/template/resource_test.go
+++ b/resource/template/resource_test.go
@@ -108,9 +108,7 @@ func TestProcessTemplateResources(t *testing.T) {
 
 	// Create the stub etcd client.
 	c := etcdtest.NewClient()
-	fooResp := []*etcd.Response{
-		{Key: "/foo", Dir: false, Value: "bar"},
-	}
+	fooResp := &etcd.Response{Action: "GET", Node: &etcd.Node{Key: "/foo", Dir: false, Value: "bar"}}
 	c.AddResponse("/foo", fooResp)
 
 	// Process the test template resource.
@@ -184,9 +182,7 @@ func TestProcessTemplateResourcesNoop(t *testing.T) {
 
 	// Create the stub etcd client.
 	c := etcdtest.NewClient()
-	fooResp := []*etcd.Response{
-		{Key: "/foo", Dir: false, Value: "bar"},
-	}
+	fooResp := &etcd.Response{Action: "GET", Node: &etcd.Node{Key: "/foo", Dir: false, Value: "bar"}}
 	c.AddResponse("/foo", fooResp)
 
 	// Process the test template resource.


### PR DESCRIPTION
Made changes necessary to support new signature for etcd.Client.Get. Was
Get(key string). Now Get(key string, sort, recursive bool)

Made changes to support new structure of etcd.Response.

Refactored etcdutil.etcdWalk to use pointers to nodes to walk the tree,
eliminating the need to query etcd for each child node. This work also exposed
an infinite loop in the previous implementation of etcdWalk when one of
the keys in the toml configuration was a node whose Dir property was
true.
