### PR TITLE
Adapt to NewTLSClient change in go-etcd, add CaKeys support

### DIFF
--- a/confd.go
+++ b/confd.go
@@ -50,7 +50,7 @@ func main() {
 	// Create the etcd client upfront and use it for the life of the process.
 	// The etcdClient is an http.Client and designed to be reused.
 	log.Notice("etcd nodes set to " + strings.Join(config.EtcdNodes(), ", "))
-	etcdClient, err := etcdutil.NewEtcdClient(config.EtcdNodes(), config.ClientCert(), config.ClientKey())
+	etcdClient, err := etcdutil.NewEtcdClient(config.EtcdNodes(), config.ClientCert(), config.ClientKey(), config.ClientCaKeys())
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -16,19 +16,20 @@ import (
 )
 
 var (
-	clientCert string
-	clientKey  string
-	config     Config // holds the global confd config.
-	confdir    string
-	debug      bool
-	etcdNodes  Nodes
-	etcdScheme string
-	interval   int
-	noop       bool
-	prefix     string
-	quiet      bool
-	srvDomain  string
-	verbose    bool
+	clientCert   string
+	clientKey    string
+	clientCaKeys string
+	config       Config // holds the global confd config.
+	confdir      string
+	debug        bool
+	etcdNodes    Nodes
+	etcdScheme   string
+	interval     int
+	noop         bool
+	prefix       string
+	quiet        bool
+	srvDomain    string
+	verbose      bool
 )
 
 // Config represents the confd configuration settings.
@@ -38,24 +39,26 @@ type Config struct {
 
 // confd represents the parsed configuration settings.
 type confd struct {
-	Debug      bool     `toml:"debug"`
-	ClientCert string   `toml:"client_cert"`
-	ClientKey  string   `toml:"client_key"`
-	ConfDir    string   `toml:"confdir"`
-	EtcdNodes  []string `toml:"etcd_nodes"`
-	EtcdScheme string   `toml:"etcd_scheme"`
-	Interval   int      `toml:"interval"`
-	Noop       bool     `toml:"noop"`
-	Prefix     string   `toml:"prefix"`
-	Quiet      bool     `toml:"quiet"`
-	SRVDomain  string   `toml:"srv_domain"`
-	Verbose    bool     `toml:"verbose"`
+	Debug        bool     `toml:"debug"`
+	ClientCert   string   `toml:"client_cert"`
+	ClientKey    string   `toml:"client_key"`
+	ClientCaKeys string   `toml:"client_cakeys"`
+	ConfDir      string   `toml:"confdir"`
+	EtcdNodes    []string `toml:"etcd_nodes"`
+	EtcdScheme   string   `toml:"etcd_scheme"`
+	Interval     int      `toml:"interval"`
+	Noop         bool     `toml:"noop"`
+	Prefix       string   `toml:"prefix"`
+	Quiet        bool     `toml:"quiet"`
+	SRVDomain    string   `toml:"srv_domain"`
+	Verbose      bool     `toml:"verbose"`
 }
 
 func init() {
 	flag.BoolVar(&debug, "debug", false, "enable debug logging")
 	flag.StringVar(&clientCert, "client-cert", "", "the client cert")
 	flag.StringVar(&clientKey, "client-key", "", "the client key")
+	flag.StringVar(&clientCaKeys, "client-ca-keys", "", "client ca keys")
 	flag.StringVar(&confdir, "confdir", "/etc/confd", "confd conf directory")
 	flag.Var(&etcdNodes, "node", "list of etcd nodes")
 	flag.StringVar(&etcdScheme, "etcd-scheme", "http", "the etcd URI scheme. (http or https)")
@@ -106,6 +109,11 @@ func ClientCert() string {
 // ClientKey returns the client key path.
 func ClientKey() string {
 	return config.Confd.ClientKey
+}
+
+// ClientCaKeys returns the client CA certificates
+func ClientCaKeys() string {
+        return config.Confd.ClientCaKeys
 }
 
 // ConfDir returns the path to the confd config dir.
@@ -250,6 +258,8 @@ func setConfigFromFlag(f *flag.Flag) {
 		config.Confd.ClientCert = clientCert
 	case "client-key":
 		config.Confd.ClientKey = clientKey
+	case "client-cakeys":
+		config.Confd.ClientCaKeys = clientCaKeys
 	case "confdir":
 		config.Confd.ConfDir = confdir
 	case "node":

--- a/etcd/etcdutil/client.go
+++ b/etcd/etcdutil/client.go
@@ -13,13 +13,15 @@ var replacer = strings.NewReplacer("/", "_")
 
 // NewEtcdClient returns an *etcd.Client with a connection to named machines.
 // It returns an error if a connection to the cluster cannot be made.
-func NewEtcdClient(machines []string, cert, key string) (*etcd.Client, error) {
-	c := etcd.NewClient(machines)
+func NewEtcdClient(machines []string, cert, key string, caCert string) (*etcd.Client, error) {
+	var c *etcd.Client
 	if cert != "" && key != "" {
-		err := c.SetCertAndKey(cert, key)
+		c, err := etcd.NewTLSClient(machines, cert, key, caCert)
 		if err != nil {
 			return c, err
 		}
+	} else {
+		c = etcd.NewClient(machines)
 	}
 	success := c.SetCluster(machines)
 	if !success {


### PR DESCRIPTION
This is needed to compile `confd` against anything after coreos/go-etcd@51a26f8d6a, which deprecates `SetCertAndKey` and requires a CA certificate chain.

Test suite seems to pass and the binary is working for me.  Otherwise I don't see much in the way of contribution guidelines, so let me know if there anything else I should do.
