### PR TITLE
Add directory value and path.Base for complex iteration

### DIFF
--- a/etcd/etcdutil/client.go
+++ b/etcd/etcdutil/client.go
@@ -56,10 +56,11 @@ func GetValues(c EtcdClient, prefix string, keys []string) (map[string]interface
 // nodeWalk recursively descends nodes, updating vars.
 func nodeWalk(node *etcd.Node, prefix string, vars map[string]interface{}) error {
 	if node != nil {
+		key := pathToKey(node.Key, prefix)
 		if !node.Dir {
-			key := pathToKey(node.Key, prefix)
 			vars[key] = node.Value
 		} else {
+			vars[key] = node.Nodes
 			for _, node := range node.Nodes {
 				nodeWalk(&node, prefix, vars)
 			}

--- a/resource/template/resource.go
+++ b/resource/template/resource.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strconv"
 	"syscall"
@@ -89,7 +90,10 @@ func (t *TemplateResource) createStageFile() error {
 		return err
 	}
 	log.Debug("Compiling source template " + t.Src)
-	tmpl := template.Must(template.ParseFiles(t.Src))
+	// define function namespace for template processing
+	tplFuncMap := make(template.FuncMap)
+	tplFuncMap["Base"] = path.Base
+	tmpl := template.Must(template.New(path.Base(t.Src)).Funcs(tplFuncMap).ParseFiles(t.Src))
 	if err = tmpl.Execute(temp, t.Vars); err != nil {
 		return err
 	}


### PR DESCRIPTION
There is currently no way to iterate over directories during template processing.  This PR aims to change that (though a work in progress).

By adding `node.Nodes` as the directory value during the `nodeWalk`, we can perform range operations that make the following template possible:

```
{{ range $user := .deis_builder_users }}{{ range $key := $user.Nodes }}
command="/app/gitreceive run {{ Base $user.Key }} {{ Base $key.Key }}",no-agent-forwarding,no-pty,no-user-rc,no-X11-forwarding,no-port-forwarding {{ $key.Value }}
{{ end }}{{ end }}
```
