### PR TITLE
Update installation.md to prevent wierd S3 name when downloading

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,7 +13,7 @@ wget https://github.com/kelseyhightower/confd/releases/download/v0.2.0/confd_0.2
 ```
 * LINUX
 ```Bash
-wget https://github.com/kelseyhightower/confd/releases/download/v0.2.0/confd_0.2.0_linux_amd64.tar.gz
+wget -O confd_0.2.0_linux_amd64.tar.gz https://github.com/kelseyhightower/confd/releases/download/v0.2.0/confd_0.2.0_linux_amd64.tar.gz
 ```
 
 Unzip the confd package.


### PR DESCRIPTION
To prevent weird Amazon S3 name to be the result of the download. With the current code the ouput file could be called something like `702fe616-4502-11e3-8d9a-b95576a2176f.gz\?response-content-disposition\=attachment\;\ filename\=confd_0.2.0_linux_amd64.tar.gz\&AWSAccessKeyId\=AKIAISTNZFOVBIJMK3TQ\&Expires\=1394028017\&Signature\=3%2FpqUGYkufhsv0Z4SrMn7oQ4sW0\=`
