### PR TITLE
Defer tempfile close to avoid dangling FDs

### DIFF
--- a/resource/template/resource.go
+++ b/resource/template/resource.go
@@ -89,6 +89,7 @@ func (t *TemplateResource) createStageFile() error {
 		os.Remove(temp.Name())
 		return err
 	}
+        defer temp.Close()
 	log.Debug("Compiling source template " + t.Src)
 	tplFuncMap := make(template.FuncMap)
 	tplFuncMap["Base"] = path.Base


### PR DESCRIPTION
Though the `tempfile` is being deleted later in the function, the file descriptor remains open.  This causes strange `ETXTBSY` errors under certain conditions.
