### PR TITLE
change version id to 0.3.0 and update download path in docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,24 +6,24 @@ Currently confd ships binaries for OS X and Linux 64bit systems. You can downloa
 
 > Note: You don't need Go installed to use confd unless you plan to build from source.
 
-Download confd version 0.2.0 using wget from the command line:
+Download confd version 0.3.0 using wget from the command line:
 * OSX
 ```Bash
-wget https://github.com/kelseyhightower/confd/releases/download/v0.2.0/confd_0.2.0_darwin_amd64.zip
+wget https://github.com/kelseyhightower/confd/releases/download/v0.3.0/confd_0.3.0_darwin_amd64.zip
 ```
 * LINUX
 ```Bash
-wget -O confd_0.2.0_linux_amd64.tar.gz https://github.com/kelseyhightower/confd/releases/download/v0.2.0/confd_0.2.0_linux_amd64.tar.gz
+wget -O confd_0.3.0_linux_amd64.tar.gz https://github.com/kelseyhightower/confd/releases/download/v0.3.0/confd_0.3.0_linux_amd64.tar.gz
 ```
 
 Unzip the confd package.
 * OSX
 ```Bash
-unzip confd_0.2.0_darwin_amd64.zip
+unzip confd_0.3.0_darwin_amd64.zip
 ```
 * LINUX
 ```Bash
-tar -zxvf confd_0.2.0_linux_amd64.tar.gz
+tar -zxvf confd_0.3.0_linux_amd64.tar.gz
 ```
 
 Copy the confd binary to a bin directory in your path.

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version = "0.2.0"
+const Version = "0.3.0"


### PR DESCRIPTION
I saw you had released version 0.3.0, I just updated version.go and the paths used for downloads/unpacking in installation.md
