### PR TITLE
make key cleaning for templates recursive

### DIFF
--- a/resource/template/resource.go
+++ b/resource/template/resource.go
@@ -118,7 +118,7 @@ func (t *TemplateResource) createStageFile() error {
 	tplFuncMap["Base"] = path.Base
 
 	tplFuncMap["GetDir"] = t.Dirs.Get
-    tplFuncMap["MapDir"] = mapNodes
+	tplFuncMap["MapDir"] = mapNodes
 	tmpl := template.Must(template.New(path.Base(t.Src)).Funcs(tplFuncMap).ParseFiles(t.Src))
 	if err = tmpl.Execute(temp, t.Vars); err != nil {
 		return err

--- a/resource/template/util.go
+++ b/resource/template/util.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/coreos/go-etcd/etcd"
 	"github.com/kelseyhightower/confd/log"
-    "github.com/coreos/go-etcd/etcd"
 )
 
 func appendPrefix(prefix string, keys []string) []string {
@@ -37,14 +37,14 @@ func cleanKeys(vars map[string]interface{}, prefix string) map[string]interface{
 
 func mapNodes(node *etcd.Node) map[string]interface{} {
 	result := make(map[string]interface{})
-    for _, node := range node.Nodes {
-        if len(node.Nodes) > 0 {
-            result[node.Key] = node.Nodes
-        } else {
-            result[node.Key] = node.Value
-        }
-    }
-    return cleanKeys(result, node.Key)
+	for _, node := range node.Nodes {
+		if len(node.Nodes) > 0 {
+			result[node.Key] = node.Nodes
+		} else {
+			result[node.Key] = node.Value
+		}
+	}
+	return cleanKeys(result, node.Key)
 }
 
 // isFileExist reports whether path exits.


### PR DESCRIPTION
etcd backends can now resolve keys recursively into maps rather than etcd.Nodes objects for templates.
