### PR TITLE
os.Rename cross-filesystem issue alternative solution

### DIFF
--- a/resource/template/resource.go
+++ b/resource/template/resource.go
@@ -107,7 +107,8 @@ func (t *TemplateResource) createStageFile() error {
 	if !isFileExist(t.Src) {
 		return errors.New("Missing template: " + t.Src)
 	}
-	temp, err := ioutil.TempFile("", "")
+	// create TempFile in Dest directory to avoid cross-filesystem issues
+	temp, err := ioutil.TempFile(filepath.Dir(t.Dest), "." + filepath.Base(t.Dest))
 	if err != nil {
 		os.Remove(temp.Name())
 		return err


### PR DESCRIPTION
https://github.com/kelseyhightower/confd/pull/69 apparently has issues due to failing builds, so I took a look at it and would like to propose an alternative solution.

Since we're creating a tempfile, and the issue is renaming that tempfile across file systems,  why not just create the tempfile on the same filesystem as the destination file?

This seems like a much simpler change to me.
