### PR TITLE
Integrate etcd and consul watch

### DIFF
--- a/backends/env/client.go
+++ b/backends/env/client.go
@@ -28,6 +28,16 @@ func (c *Client) GetValues(keys []string) (map[string]interface{}, error) {
 	return vars, nil
 }
 
+func (c *Client) WatchValues(keys []string, varChan chan map[string]interface{}) error {
+	vars, err := c.GetValues(keys)
+	if err != nil {
+		return err
+	}
+	varChan <-vars
+	close(varChan)
+	return nil
+}
+
 func transform(key string) string {
 	k := strings.TrimPrefix(key, "/")
 	return strings.ToUpper(replacer.Replace(k))

--- a/backends/etcd/etcdtest/client.go
+++ b/backends/etcd/etcdtest/client.go
@@ -17,6 +17,13 @@ func (c *Client) Get(key string, sort, recurse bool) (*etcd.Response, error) {
 	return c.Responses[key], nil
 }
 
+// Watch mimics the etcd.Client.Watch() method
+func (c *Client) Watch(key string, waitIndex uint64, recurse bool, receiver chan *etcd.Response, stop chan bool) (*etcd.Response, error) {
+	receiver <- c.Responses[key]
+	close(receiver)
+	return nil, nil
+}
+
 // AddResponses adds or updates the Client.Responses map.
 func (c *Client) AddResponse(key string, response *etcd.Response) {
 	c.Responses[key] = response

--- a/backends/etcd/etcdutil/client_test.go
+++ b/backends/etcd/etcdutil/client_test.go
@@ -73,3 +73,74 @@ func TestGetValues(t *testing.T) {
 		t.Errorf("Expected quux == foo, got %s", values["quux"])
 	}
 }
+
+func TestWatchValues(t *testing.T) {
+	// Use stub etcd client.
+	c := etcdtest.NewClient()
+	client := &Client{c}
+
+	fooResp := &etcd.Response{
+		Action: "GET",
+		Node: &etcd.Node{
+			Key:   "/foo",
+			Dir:   true,
+			Value: "",
+			Nodes: etcd.Nodes{
+				&etcd.Node{Key: "/foo/one", Dir: false, Value: "one"},
+				&etcd.Node{Key: "foo/two", Dir: false, Value: "two"},
+				&etcd.Node{
+					Key:   "/foo/three",
+					Dir:   true,
+					Value: "",
+					Nodes: etcd.Nodes{
+						&etcd.Node{Key: "/foo/three/bar", Value: "three_bar", Dir: false},
+					},
+				},
+			},
+		},
+	}
+	quuxResp := &etcd.Response{
+		Action: "GET",
+		Node:   &etcd.Node{Key: "/quux", Dir: false, Value: "foo"},
+	}
+	nginxResp := &etcd.Response{
+		Action: "GET",
+		Node: &etcd.Node{
+			Key:   "/nginx",
+			Value: "",
+			Dir:   true,
+			Nodes: etcd.Nodes{
+				&etcd.Node{Key: "/nginx/port", Dir: false, Value: "443"},
+				&etcd.Node{Key: "/nginx/worker_processes", Dir: false, Value: "4"},
+			},
+		},
+	}
+
+	c.AddResponse("/foo", fooResp)
+	c.AddResponse("/quux", quuxResp)
+	c.AddResponse("/nginx", nginxResp)
+	keys := []string{"/nginx", "/quux", "/foo"}
+
+	updateChan := make(chan map[string]interface{})
+	go client.WatchValues(keys, updateChan)
+
+	//// Block until the channel is drained. This should normally be done
+	//// within a for/select loop, but we need synchronous tests.
+	values := make(map[string]interface{})
+	for val := range updateChan {
+		values = val
+	}
+
+	if values["/nginx/port"] != "443" {
+		t.Errorf("Expected nginx_port to == 443, got %s", values["nginx_port"])
+	}
+	if values["/nginx/worker_processes"] != "4" {
+		t.Errorf("Expected nginx_worker_processes == 4, got %s", values["nginx_worker_processes"])
+	}
+	if values["/foo/three/bar"] != "three_bar" {
+		t.Errorf("Expected foo_three_bar == three_bar, got %s", values["foo_three_bar"])
+	}
+	if values["/quux"] != "foo" {
+		t.Errorf("Expected quux == foo, got %s", values["quux"])
+	}
+}

--- a/backends/store_client.go
+++ b/backends/store_client.go
@@ -15,6 +15,7 @@ import (
 // key/value pairs from a backend store.
 type StoreClient interface {
 	GetValues(keys []string) (map[string]interface{}, error)
+	WatchValues(keys []string, varChan chan map[string]interface{}) error
 }
 
 // New is used to create a storage client based on our configuration.

--- a/confd.go
+++ b/confd.go
@@ -49,6 +49,10 @@ func main() {
 	if err := config.LoadConfig(configFile); err != nil {
 		log.Fatal(err.Error())
 	}
+	// a `onetime` flag should override `watch`
+	if onetime {
+		config.SetWatch(false)
+	}
 	// Configure logging. While you can enable debug and verbose logging, however
 	// if quiet is set to true then debug and verbose messages will not be printed.
 	log.SetQuiet(config.Quiet())

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ var (
 	etcdNodes    Nodes
 	etcdScheme   string
 	interval     int
+	watch	     bool
 	noop         bool
 	prefix       string
 	quiet        bool
@@ -54,6 +55,7 @@ type confd struct {
 	EtcdNodes    []string `toml:"etcd_nodes"`
 	EtcdScheme   string   `toml:"etcd_scheme"`
 	Interval     int      `toml:"interval"`
+	Watch        bool     `toml:"watch"`
 	Noop         bool     `toml:"noop"`
 	Prefix       string   `toml:"prefix"`
 	Quiet        bool     `toml:"quiet"`
@@ -73,6 +75,7 @@ func init() {
 	flag.Var(&etcdNodes, "node", "list of etcd nodes")
 	flag.StringVar(&etcdScheme, "etcd-scheme", "http", "the etcd URI scheme. (http or https)")
 	flag.IntVar(&interval, "interval", 600, "etcd polling interval")
+	flag.BoolVar(&watch, "watch", false, "watch backend for changes")
 	flag.BoolVar(&noop, "noop", false, "only show pending changes, don't sync configs.")
 	flag.StringVar(&prefix, "prefix", "/", "etcd key path prefix")
 	flag.BoolVar(&quiet, "quiet", false, "enable quiet logging. Only error messages are printed.")
@@ -167,6 +170,11 @@ func Interval() int {
 	return config.Confd.Interval
 }
 
+// Watch reports whether watch mode is enabled.
+func Watch() bool {
+	return config.Confd.Watch
+}
+
 // Noop reports whether noop mode is enabled.
 func Noop() bool {
 	return config.Confd.Noop
@@ -190,6 +198,11 @@ func Verbose() bool {
 // SetConfDir sets the confd conf dir.
 func SetConfDir(path string) {
 	config.Confd.ConfDir = path
+}
+
+// SetWatch sets watch mode.
+func SetWatch(enabled bool) {
+	config.Confd.Watch = enabled
 }
 
 // SetNoop sets noop.
@@ -305,6 +318,8 @@ func setConfigFromFlag(f *flag.Flag) {
 		config.Confd.EtcdScheme = etcdScheme
 	case "interval":
 		config.Confd.Interval = interval
+	case "watch":
+		config.Confd.Watch = watch
 	case "noop":
 		config.Confd.Noop = noop
 	case "prefix":

--- a/docs/command-line-flags.md
+++ b/docs/command-line-flags.md
@@ -21,7 +21,8 @@ Usage of confd:
   -interval=600: etcd polling interval
   -node=[]: list of etcd nodes
   -noop=false: only show pending changes, don't sync configs.
-  -onetime=false: run once and exit
+  -onetime=false: run once and exit.
+  -watch=false: watch backend for changes
   -prefix="/": etcd key path prefix
   -quiet=false: enable quiet logging. Only error messages are printed.
   -srv-domain="": the domain to query for the etcd SRV record, i.e. example.com

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -24,6 +24,7 @@ Optional:
 * `interval` (int) - The number of seconds to wait between calls to etcd. The
   default is 600.
 * `noop` (bool) - Enable noop mode. Process all template resource, but don't update target config.
+* `watch` (bool) - Watch backend for changes.
 * `prefix` (string) - The prefix string to prefix to keys when making calls to
   etcd. The default is "/".
 * `quiet` (bool) - Enable quiet logging. Only error messages are printed.

--- a/docs/etcd-usage-examples.md
+++ b/docs/etcd-usage-examples.md
@@ -20,6 +20,16 @@ confd -interval 30 -prefix '/production' -node 'http://127.0.0.1:4001' -noop
 
 See [Noop mode](noop-mode.md)
 
+### Watch backend for changes
+
+Using default settings run one time and exit.
+
+```
+confd -watch -prefix '/production' -node 'http://127.0.0.1:4001'
+```
+
+Note: `watch` is overriden by passing the `onetime` flag.
+
 ### Single run without polling
 
 Using default settings run one time and exit.

--- a/integration/etcd/watch_test.sh
+++ b/integration/etcd/watch_test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+etcd_host=${1}
+etcd_port=${2}
+
+# Configure etcd
+curl -L -X PUT http://${etcd_host}:${etcd_port}/v2/keys/database/host -d value=127.0.0.1
+curl -L -X PUT http://${etcd_host}:${etcd_port}/v2/keys/database/password -d value=p@sSw0rd
+curl -L -X PUT http://${etcd_host}:${etcd_port}/v2/keys/database/port -d value=3306
+curl -L -X PUT http://${etcd_host}:${etcd_port}/v2/keys/database/username -d value=confd
+curl -L -X PUT http://${etcd_host}:${etcd_port}/v2/keys/upstream/app1 -d value=10.0.1.10:8080
+curl -L -X PUT http://${etcd_host}:${etcd_port}/v2/keys/upstream/app2 -d value=10.0.1.11:8080
+
+# Run confd
+./confd -watch -confdir ./integration/confdir -backend etcd -node "http://${etcd_host}:${etcd_port}" &
+confd_pid=$!
+
+sleep 1
+
+curl -L -X PUT http://${etcd_host}:${etcd_port}/v2/keys/database/host -d value=127.9.9.9
+curl -L -X PUT http://${etcd_host}:${etcd_port}/v2/keys/database/password -d value=W4tch3Dp@sSw0rd
+curl -L -X PUT http://${etcd_host}:${etcd_port}/v2/keys/database/port -d value=3307
+curl -L -X PUT http://${etcd_host}:${etcd_port}/v2/keys/database/username -d value=watchedconfd
+curl -L -X PUT http://${etcd_host}:${etcd_port}/v2/keys/upstream/app1 -d value=20.0.2.20:8080
+curl -L -X PUT http://${etcd_host}:${etcd_port}/v2/keys/upstream/app2 -d value=20.0.2.22:8080
+
+sleep 1
+
+kill ${confd_pid}

--- a/resource/template/resource.go
+++ b/resource/template/resource.go
@@ -41,6 +41,7 @@ type TemplateResource struct {
 	Prefix      string
 	StageFile   *os.File
 	Src         string
+	SrcPath     string
 	Vars        map[string]interface{}
 	Dirs        node.Directory
 	storeClient backends.StoreClient
@@ -64,17 +65,34 @@ func NewTemplateResourceFromPath(path string, s backends.StoreClient) (*Template
 }
 
 // setVars sets the Vars for template resource.
-func (t *TemplateResource) setVars() error {
-	var err error
+func (t *TemplateResource) setVars(continueChan chan bool) error {
 	log.Debug("Retrieving keys from store")
 	log.Debug("Key prefix set to " + t.prefix())
-	vars, err := t.storeClient.GetValues(appendPrefix(t.prefix(), t.Keys))
-	if err != nil {
-		return err
+	if continueChan == nil {
+		vars, err := t.storeClient.GetValues(appendPrefix(t.prefix(), t.Keys))
+		if err != nil {
+			return err
+		}
+		t.setDirs(vars)
+		t.Vars = cleanKeys(vars, t.prefix())
+		return nil
 	}
-	t.setDirs(vars)
-	t.Vars = cleanKeys(vars, t.prefix())
-	return nil
+
+	varChan := make(chan map[string]interface{})
+	defer close(continueChan)
+
+	go t.storeClient.WatchValues(appendPrefix(t.prefix(), t.Keys), varChan)
+	for {
+		select {
+		case vars, ok := <-varChan:
+			if !ok {
+				return nil
+			}
+			t.setDirs(vars)
+			t.Vars = cleanKeys(vars, t.prefix())
+			continueChan <- true
+		}
+	}
 }
 
 func (t *TemplateResource) prefix() string {
@@ -106,10 +124,10 @@ func (t *TemplateResource) setDirs(vars map[string]interface{}) {
 // StageFile for the template resource.
 // It returns an error if any.
 func (t *TemplateResource) createStageFile() error {
-	t.Src = filepath.Join(config.TemplateDir(), t.Src)
-	log.Debug("Using source template " + t.Src)
-	if !isFileExist(t.Src) {
-		return errors.New("Missing template: " + t.Src)
+	t.SrcPath = filepath.Join(config.TemplateDir(), t.Src)
+	log.Debug("Using source template " + t.SrcPath)
+	if !isFileExist(t.SrcPath) {
+		return errors.New("Missing template: " + t.SrcPath)
 	}
 	// create TempFile in Dest directory to avoid cross-filesystem issues
 	temp, err := ioutil.TempFile(filepath.Dir(t.Dest), "."+filepath.Base(t.Dest))
@@ -117,13 +135,13 @@ func (t *TemplateResource) createStageFile() error {
 		return err
 	}
 	defer temp.Close()
-	log.Debug("Compiling source template " + t.Src)
+	log.Debug("Compiling source template " + t.SrcPath)
 	tplFuncMap := make(template.FuncMap)
 	tplFuncMap["Base"] = path.Base
 
 	tplFuncMap["GetDir"] = t.Dirs.Get
 	tplFuncMap["MapDir"] = mapNodes
-	tmpl := template.Must(template.New(path.Base(t.Src)).Funcs(tplFuncMap).ParseFiles(t.Src))
+	tmpl := template.Must(template.New(path.Base(t.SrcPath)).Funcs(tplFuncMap).ParseFiles(t.SrcPath))
 	if err = tmpl.Execute(temp, t.Vars); err != nil {
 		return err
 	}
@@ -224,16 +242,34 @@ func (t *TemplateResource) process() error {
 	if err := t.setFileMode(); err != nil {
 		return err
 	}
-	if err := t.setVars(); err != nil {
-		return err
+
+	if !config.Watch() {
+		if err := t.setVars(nil); err != nil {
+			return err
+		}
+		if err := t.createStageFile(); err != nil {
+			return err
+		}
+		if err := t.sync(); err != nil {
+			return err
+		}
+		return nil
 	}
-	if err := t.createStageFile(); err != nil {
-		return err
+
+	continueChannel := make(chan bool)
+	go t.setVars(continueChannel)
+	for {
+		_, ok := <-continueChannel
+		if !ok {
+			return nil
+		}
+		if err := t.createStageFile(); err != nil {
+			return err
+		}
+		if err := t.sync(); err != nil {
+			return err
+		}
 	}
-	if err := t.sync(); err != nil {
-		return err
-	}
-	return nil
 }
 
 // setFileMode sets the FileMode.


### PR DESCRIPTION
I took a quick stab at integrating etcd and consul's watch features per issue #56. This update basically wraps the go-etcd `Watch` command and consul's `WatchList` so they both have the same interface (go-etcd uses goroutines/channels while consul is a long-poll).

It adds a `-watch` flag that takes precedence over any intervals:
`confd -watch -node 'http://127.0.0.1:4001' -confdir ~/confd`
