### PR TITLE
JSON parsing functions

### DIFF
--- a/resource/template/resource.go
+++ b/resource/template/resource.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
-  "encoding/json"
+	"encoding/json"
 
 	"github.com/BurntSushi/toml"
 	"github.com/kelseyhightower/confd/backends"
@@ -125,16 +125,16 @@ func (t *TemplateResource) createStageFile() error {
 	tplFuncMap["GetDir"] = t.Dirs.Get
 	tplFuncMap["MapDir"] = mapNodes
 
-  tplFuncMap["JsonUnmarshalObject"] = func(j string) (map[string]interface{}, error) {
-    var ret map[string]interface{}
-    err = json.Unmarshal([]byte(j), &ret)
-    return ret, err
-  }
-  tplFuncMap["JsonUnmarshalArray"] = func(j string) ([]interface{}, error) {
-    var ret []interface{}
-    err = json.Unmarshal([]byte(j), &ret)
-    return ret, err
-  }
+	tplFuncMap["JsonUnmarshalObject"] = func(j string) (map[string]interface{}, error) {
+	var ret map[string]interface{}
+		err = json.Unmarshal([]byte(j), &ret)
+		return ret, err
+	}
+	tplFuncMap["JsonUnmarshalArray"] = func(j string) ([]interface{}, error) {
+	var ret []interface{}
+		err = json.Unmarshal([]byte(j), &ret)
+		return ret, err
+	}
 
 	tmpl := template.Must(template.New(path.Base(t.Src)).Funcs(tplFuncMap).ParseFiles(t.Src))
 	if err = tmpl.Execute(temp, t.Vars); err != nil {


### PR DESCRIPTION
We use confd with etcd.  In etcd, we often store values in JSON.  We added two very basic mapped functions to the template parser that allows use to handle JSON values inside of templates - one for objects, and one for arrays.

Usage example:

```
{{with $c := JsonUnmarshalObject $container.Value}}
  {{printf "%s:%.0f" $c.ip $c.ports.web}};
{{end}}
```
