### PR TITLE
sort results from etcd so keys are always in the same order

### DIFF
--- a/backends/etcd/etcdutil/client.go
+++ b/backends/etcd/etcdutil/client.go
@@ -47,7 +47,7 @@ func NewEtcdClient(machines []string, cert, key string, caCert string) (*Client,
 func (c *Client) GetValues(keys []string) (map[string]interface{}, error) {
 	vars := make(map[string]interface{})
 	for _, key := range keys {
-		resp, err := c.client.Get(key, false, true)
+		resp, err := c.client.Get(key, true, true)
 		if err != nil {
 			return vars, err
 		}


### PR DESCRIPTION
Fix for issue 107.

The problem this addresses is that the order of keys can change if they are expiring and being reset, even when they contain the same value.  This change asks etcd to return the keys in a sorted order.
