### PR TITLE
Set DialTimeout in etcd client

### DIFF
--- a/backends/etcd/etcdutil/client.go
+++ b/backends/etcd/etcdutil/client.go
@@ -6,6 +6,7 @@ package etcdutil
 import (
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/coreos/go-etcd/etcd"
 )
@@ -31,6 +32,8 @@ func NewEtcdClient(machines []string, cert, key string, caCert string) (*Client,
 	} else {
 		c = etcd.NewClient(machines)
 	}
+	// Configure the DialTimeout, since 1 second is often too short
+	c.SetDialTimeout(time.Duration(3) * time.Second)
 	success := c.SetCluster(machines)
 	if !success {
 		return &Client{c}, errors.New("cannot connect to etcd cluster: " + strings.Join(machines, ","))


### PR DESCRIPTION
One second (the default) isn't long enough for many tasks.
