### PR TITLE
fixes #119

### DIFF
--- a/backends/etcd/etcdutil/client.go
+++ b/backends/etcd/etcdutil/client.go
@@ -24,8 +24,9 @@ type EtcdClient interface {
 // It returns an error if a connection to the cluster cannot be made.
 func NewEtcdClient(machines []string, cert, key string, caCert string) (*Client, error) {
 	var c *etcd.Client
+	var err error
 	if cert != "" && key != "" {
-		c, err := etcd.NewTLSClient(machines, cert, key, caCert)
+		c, err = etcd.NewTLSClient(machines, cert, key, caCert)
 		if err != nil {
 			return &Client{c}, err
 		}


### PR DESCRIPTION
"c, err := .... " will override variable "c" defined before.
