### PR TITLE
add watch support

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -17,7 +17,7 @@
 		},
 		{
 			"ImportPath": "github.com/kelseyhightower/memkv",
-			"Rev": "7d7193e3d32638476ea5c041e28a71987660a80c"
+			"Rev": "b74c6f62d677ca9c4d0213bb67256a22a26f981e"
 		}
 	]
 }

--- a/Godeps/_workspace/src/github.com/kelseyhightower/memkv/store.go
+++ b/Godeps/_workspace/src/github.com/kelseyhightower/memkv/store.go
@@ -20,13 +20,23 @@ var ErrNoMatch = errors.New("no keys match")
 // A Store represents an in-memory key-value store safe for
 // concurrent access.
 type Store struct {
+	FuncMap map[string]interface{}
 	sync.RWMutex
 	m map[string]KVPair
 }
 
 // New creates and initializes a new Store.
 func New() Store {
-	return Store{m: make(map[string]KVPair)}
+	s := Store{m: make(map[string]KVPair)}
+	s.FuncMap = map[string]interface{}{
+		"ls":    s.List,
+		"lsdir": s.ListDir,
+		"get":   s.Get,
+		"gets":  s.GetAll,
+		"getv":  s.GetValue,
+		"getvs": s.GetAllValues,
+	}
+	return s
 }
 
 // Delete deletes the KVPair associated with key.

--- a/backends/client.go
+++ b/backends/client.go
@@ -14,6 +14,7 @@ import (
 // key/value pairs from a backend store.
 type StoreClient interface {
 	GetValues(keys []string) (map[string]string, error)
+	WatchPrefix(prefix string, waitIndex uint64, stopChan chan bool) (uint64, error)
 }
 
 // New is used to create a storage client based on our configuration.

--- a/backends/env/client.go
+++ b/backends/env/client.go
@@ -46,3 +46,8 @@ func clean(key string) string {
 	newKey := "/" + key
 	return cleanReplacer.Replace(strings.ToLower(newKey))
 }
+
+func (c *Client) WatchPrefix(prefix string, waitIndex uint64, stopChan chan bool) (uint64, error) {
+	<-stopChan
+	return 0, nil
+}

--- a/backends/etcd/client.go
+++ b/backends/etcd/client.go
@@ -1,6 +1,3 @@
-// Copyright (c) 2013 Kelsey Hightower. All rights reserved.
-// Use of this source code is governed by the Apache License, Version 2.0
-// that can be found in the LICENSE file.
 package etcd
 
 import (
@@ -67,4 +64,16 @@ func nodeWalk(node *goetcd.Node, vars map[string]string) error {
 		}
 	}
 	return nil
+}
+
+func (c *Client) WatchPrefix(prefix string, waitIndex uint64, stopChan chan bool) (uint64, error) {
+	if waitIndex == 0 {
+		resp, err := c.client.Get(prefix, false, true)
+		if err != nil {
+			return 0, err
+		}
+		return resp.EtcdIndex, nil
+	}
+	resp, err := c.client.Watch(prefix, waitIndex+1, true, nil, stopChan)
+	return resp.Node.ModifiedIndex, err
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) 2013 Kelsey Hightower. All rights reserved.
-// Use of this source code is governed by the Apache License, Version 2.0
-// that can be found in the LICENSE file.
 package main
 
 import (

--- a/docs/command-line-flags.md
+++ b/docs/command-line-flags.md
@@ -26,6 +26,7 @@ Usage of confd:
   -srv-domain="": the name of the resource record
   -verbose=false: enable verbose logging
   -version=false: print version and exit
+  -watch=false: enable watch support
 ```
 
 > The -scheme flag is only used to set the URL scheme for nodes retrieved from DNS SRV records.

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -21,6 +21,7 @@ Optional:
 * `scheme` (string) - The backend URI scheme. ("http" or "https")
 * `srv_domain` (string) - The name of the resource record.
 * `verbose` (bool) - Enable verbose logging.
+* `watch` (bool) - Enable watch support.
 
 Example:
 

--- a/log/log.go
+++ b/log/log.go
@@ -1,7 +1,3 @@
-// Copyright (c) 2013 Kelsey Hightower. All rights reserved.
-// Use of this source code is governed by the Apache License, Version 2.0
-// that can be found in the LICENSE file.
-
 /*
 Package log provides support for logging to stdout and stderr.
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,4 +1,1 @@
-// Copyright (c) 2013 Kelsey Hightower. All rights reserved.
-// Use of this source code is governed by the Apache License, Version 2.0
-// that can be found in the LICENSE file.
 package log

--- a/node_var.go
+++ b/node_var.go
@@ -1,6 +1,3 @@
-// Copyright (c) 2013 Kelsey Hightower. All rights reserved.
-// Use of this source code is governed by the Apache License, Version 2.0
-// that can be found in the LICENSE file.
 package main
 
 import (

--- a/resource/template/processor.go
+++ b/resource/template/processor.go
@@ -1,0 +1,127 @@
+package template
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/kelseyhightower/confd/log"
+)
+
+type Processor interface {
+	Process()
+}
+
+func Process(config Config) error {
+	ts, err := getTemplateResources(config)
+	if err != nil {
+		return err
+	}
+	return process(ts)
+}
+
+func process(ts []*TemplateResource) error {
+	var lastErr error
+	for _, t := range ts {
+		if err := t.process(); err != nil {
+			log.Error(err.Error())
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+type intervalProcessor struct {
+	config   Config
+	stopChan chan bool
+	doneChan chan bool
+	errChan  chan error
+	interval int
+}
+
+func IntervalProcessor(config Config, stopChan, doneChan chan bool, errChan chan error, interval int) Processor {
+	return &intervalProcessor{config, stopChan, doneChan, errChan, interval}
+}
+
+func (p *intervalProcessor) Process() {
+	defer close(p.doneChan)
+	ts, err := getTemplateResources(p.config)
+	if err != nil {
+		return
+	}
+	for {
+		process(ts)
+		select {
+		case <-p.stopChan:
+			break
+		case <-time.After(time.Duration(p.interval) * time.Second):
+			continue
+		}
+	}
+}
+
+type watchProcessor struct {
+	config   Config
+	stopChan chan bool
+	doneChan chan bool
+	errChan  chan error
+	wg       sync.WaitGroup
+}
+
+func WatchProcessor(config Config, stopChan, doneChan chan bool, errChan chan error) Processor {
+	var wg sync.WaitGroup
+	return &watchProcessor{config, stopChan, doneChan, errChan, wg}
+}
+
+func (p *watchProcessor) Process() {
+	defer close(p.doneChan)
+	ts, err := getTemplateResources(p.config)
+	if err != nil {
+		return
+	}
+	for _, t := range ts {
+		t := t
+		p.wg.Add(1)
+		go p.monitorPrefix(t)
+	}
+	p.wg.Wait()
+}
+
+func (p *watchProcessor) monitorPrefix(t *TemplateResource) {
+	defer p.wg.Done()
+	for {
+		index, err := t.storeClient.WatchPrefix(t.Prefix, t.lastIndex, p.stopChan)
+		if err != nil {
+			p.errChan <- err
+			continue
+		}
+		t.lastIndex = index
+		if err := t.process(); err != nil {
+			p.errChan <- err
+		}
+	}
+}
+
+func getTemplateResources(config Config) ([]*TemplateResource, error) {
+	var lastError error
+	templates := make([]*TemplateResource, 0)
+	log.Debug("Loading template resources from confdir " + config.ConfDir)
+	if !isFileExist(config.ConfDir) {
+		log.Warning(fmt.Sprintf("Cannot load template resources confdir '%s' does not exist", config.ConfDir))
+		return nil, nil
+	}
+	paths, err := filepath.Glob(filepath.Join(config.ConfigDir, "*toml"))
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range paths {
+		t, err := NewTemplateResource(p, config)
+		if err != nil {
+			lastError = err
+			continue
+		}
+		templates = append(templates, t)
+	}
+	return templates, lastError
+}

--- a/resource/template/resource_test.go
+++ b/resource/template/resource_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) 2013 Kelsey Hightower. All rights reserved.
-// Use of this source code is governed by the Apache License, Version 2.0
-// that can be found in the LICENSE file.
 package template
 
 import (
@@ -96,11 +93,9 @@ func TestProcessTemplateResources(t *testing.T) {
 		TemplateDir: filepath.Join(tempConfDir, "templates"),
 	}
 	// Process the test template resource.
-	runErrors := ProcessTemplateResources(c)
-	if len(runErrors) > 0 {
-		for _, e := range runErrors {
-			t.Errorf(e.Error())
-		}
+	err = Process(c)
+	if err != nil {
+		t.Error(err.Error())
 	}
 	// Verify the results.
 	expected := "foo = bar"

--- a/resource/template/template_funcs.go
+++ b/resource/template/template_funcs.go
@@ -1,0 +1,35 @@
+package template
+
+import (
+	"encoding/json"
+	"path"
+	"strings"
+)
+
+func newFuncMap() map[string]interface{} {
+	m := make(map[string]interface{})
+	m["base"] = path.Base
+	m["split"] = strings.Split
+	m["json"] = UnmarshalJsonObject
+	m["jsonArray"] = UnmarshalJsonArray
+	m["dir"] = path.Dir
+	return m
+}
+
+func addFuncs(out, in map[string]interface{}) {
+	for name, fn := range in {
+		out[name] = fn
+	}
+}
+
+func UnmarshalJsonObject(data string) (map[string]interface{}, error) {
+	var ret map[string]interface{}
+	err := json.Unmarshal([]byte(data), &ret)
+	return ret, err
+}
+
+func UnmarshalJsonArray(data string) ([]interface{}, error) {
+	var ret []interface{}
+	err := json.Unmarshal([]byte(data), &ret)
+	return ret, err
+}

--- a/resource/template/template_test.go
+++ b/resource/template/template_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) 2013 Kelsey Hightower. All rights reserved.
-// Use of this source code is governed by the Apache License, Version 2.0
-// that can be found in the LICENSE file.
 package template
 
 import (
@@ -300,38 +297,8 @@ value: jkl
 			tr.store.Set("/test/data/jkl/mno", "789")
 		},
 	},
-
 	templateTest{
-		desc: "sibling test",
-		toml: `
-[template]
-src = "test.conf.tmpl"
-dest = "./tmp/test.conf"
-keys = [
-    "/test/data/abc",
-    "/test/data/def",
-]
-`,
-		tmpl: `
-{{with sibling "/test/data/abc" "def"}}
-key: {{.Key}}
-value: {{.Value}}
-{{end}}
-`,
-		expected: `
-
-key: /test/data/def
-value: 456
-
-`,
-		updateStore: func(tr *TemplateResource) {
-			tr.store.Set("/test/data/abc", "123")
-			tr.store.Set("/test/data/def", "456")
-		},
-	},
-
-	templateTest{
-		desc: "parent test",
+		desc: "dir test",
 		toml: `
 [template]
 src = "test.conf.tmpl"
@@ -342,13 +309,13 @@ keys = [
 ]
 `,
 		tmpl: `
-{{with parent "/test/data/abc"}}
-parent: {{.}}
+{{with dir "/test/data/abc"}}
+dir: {{.}}
 {{end}}
 `,
 		expected: `
 
-parent: /test/data
+dir: /test/data
 
 `,
 		updateStore: func(tr *TemplateResource) {
@@ -429,7 +396,7 @@ func templateResource() (*TemplateResource, error) {
 		TemplateDir: "./test/templates",
 	}
 
-	tr, err := New(tomlFilePath, config)
+	tr, err := NewTemplateResource(tomlFilePath, config)
 	if err != nil {
 		return nil, err
 	}

--- a/resource/template/util.go
+++ b/resource/template/util.go
@@ -1,6 +1,3 @@
-// Copyright (c) 2014 Kelsey Hightower. All rights reserved.
-// Use of this source code is governed by the Apache License, Version 2.0
-// that can be found in the LICENSE file.
 package template
 
 import (

--- a/version.go
+++ b/version.go
@@ -1,6 +1,3 @@
-// Copyright (c) 2014 Kelsey Hightower. All rights reserved.
-// Use of this source code is governed by the Apache License, Version 2.0
-// that can be found in the LICENSE file.
 package main
 
 const Version = "0.6.3"


### PR DESCRIPTION
confd now supports watching for changes on etcd or consul prefixes.
The watch feature can be enabled with the `-watch` flag.

A watch will be created for each template resource, and changes on a
prefix will result in templates being processed concurrently.
