### PR TITLE
Add simple zookeeper support

### DIFF
--- a/backends/client.go
+++ b/backends/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kelseyhightower/confd/backends/consul"
 	"github.com/kelseyhightower/confd/backends/env"
 	"github.com/kelseyhightower/confd/backends/etcd"
+	"github.com/kelseyhightower/confd/backends/zookeeper"
 	"github.com/kelseyhightower/confd/log"
 )
 
@@ -31,6 +32,8 @@ func New(config Config) (StoreClient, error) {
 		// Create the etcd client upfront and use it for the life of the process.
 		// The etcdClient is an http.Client and designed to be reused.
 		return etcd.NewEtcdClient(backendNodes, config.ClientCert, config.ClientKey, config.ClientCaKeys)
+	case "zookeeper":
+		return zookeeper.NewZookeeperClient(backendNodes)
 	case "env":
 		return env.NewEnvClient()
 	}

--- a/backends/zookeeper/client.go
+++ b/backends/zookeeper/client.go
@@ -1,0 +1,91 @@
+package zookeeper
+
+import (
+        "time"
+        "strings"
+
+	zk "github.com/samuel/go-zookeeper/zk"
+)
+
+
+
+// Client provides a wrapper around the zookeeper client
+type Client struct{
+    client *zk.Conn;
+}
+
+
+func NewZookeeperClient(machines []string) (*Client, error) {
+        c, _, err := zk.Connect(machines, time.Second) //*10)
+        if err != nil {
+		panic(err)
+	}
+        return &Client{c}, nil
+}
+
+
+func node_walk(prefix string, c *Client, vars map[string]string ) error{
+    l,stat,err:= c.client.Children(prefix);
+        if err != nil {
+                 return err
+        }
+
+    if (stat.NumChildren == 0) {
+        b,_, err:= c.client.Get(prefix);
+        if err != nil {
+                 return err
+        }
+        vars[prefix]=string(b)
+      
+    } else {
+    for _, key := range l {
+       s := prefix+"/"+key
+       _, stat, err := c.client.Exists(s);
+        if err != nil {
+                 return err
+        }
+        if (stat.NumChildren == 0) {
+             b,_, err:= c.client.Get(s);
+        if err != nil {
+                 return err
+        }
+             vars[s]=string(b)
+        } else {
+          node_walk(s,c,vars)
+        }
+    }
+   }
+   return nil
+}
+
+func (c *Client) GetValues(keys []string) (map[string]string, error) {
+    vars := make(map[string]string)
+    for _, v := range keys {
+        v= strings.Replace(v,"/*","",-1);
+        _, _, err := c.client.Exists(v);
+        if err != nil {
+	         return vars, err
+	}
+          if (v == "/" ) {v=""}
+          err=node_walk(v,c,vars)
+		if err != nil {
+			return vars, err
+		}
+     }
+    return vars, nil
+}
+
+
+// WatchPrefix is not yet implemented. There's a WIP.
+// Since zookeeper doesn't handle recursive watch, we need to create a *lot* of watches.
+// Implementation should take care of this.
+// A good start is bamboo
+// URL https://github.com/QubitProducts/bamboo/blob/master/qzk/qzk.go
+// We also need to encourage users to set prefix and add a flag to enale support for "" prefix (aka "/")
+//
+
+func (c *Client) WatchPrefix(prefix string, waitIndex uint64, stopChan chan bool) (uint64, error) {
+	<-stopChan
+	return 0, nil
+}
+

--- a/config.go
+++ b/config.go
@@ -148,6 +148,10 @@ func initConfig() error {
 	}
 	// Initialize the storage client
 	log.Notice("Backend set to " + config.Backend)
+        if config.Backend == "zookeeper" && config.Watch == true {
+             log.Notice("Watch is not supported for backend " + config.Backend + "exiting...")
+             os.Exit(1);
+        }
 	backendsConfig = backends.Config{
 		Backend:      config.Backend,
 		ClientCaKeys: config.ClientCaKeys,

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -35,6 +35,19 @@ export MYAPP_DATABASE_URL=db.example.com
 export MYAPP_DATABASE_USER=rob
 ```
 
+#### zookeeper
+Use zkCli.sh to add keys
+
+```
+[zk: localhost:2181(CONNECTED) 1] create /my_app "" 
+[zk: localhost:2181(CONNECTED) 2] create /my_app/database ""
+[zk: localhost:2181(CONNECTED) 3] create /my_app/database/url "db.example.com"
+[zk: localhost:2181(CONNECTED) 4] create /my_app/database/user "rob"           
+
+```
+
+Please note that zookeeper backend doesn't support watch and values from znodes with children won't be retrieved.
+
 ### Create the confdir
 
 The confdir is where template resource configs and source templates are stored.

--- a/integration/zookeeper/main.go
+++ b/integration/zookeeper/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "io/ioutil"
+    "time"
+    "strconv"
+
+    zk "github.com/samuel/go-zookeeper/zk"
+)
+
+
+
+
+func check(e error) {
+    if e != nil {
+        panic(e)
+    }
+}
+
+func zk_write( k string, v string, c *zk.Conn) {
+    e, stat, err := c.Exists(k);
+    check(err);
+    if (e) {
+      stat, err = c.Set(k, []byte(v), stat.Version)
+      check(err)
+    } else {
+      string, err := c.Create(k,[]byte(v), int32(0),zk.WorldACL(zk.PermAll));
+      if string == "" {check(err)}
+    }
+} 
+
+
+func parsejson(prefix string, x interface{}, c *zk.Conn ){
+
+    switch t := x.(type) {
+    case map[string]interface{}:
+        for k, v := range t {
+            if (prefix !="") {
+               zk_write(prefix,"", c)
+            }
+            parsejson(prefix+"/"+k, v, c)
+        }
+    case []interface{}:
+        for i, v := range t {
+            parsejson(prefix+"["+strconv.Itoa(i)+"]", v,c)
+        }
+    case string:
+        zk_write(prefix,t, c)
+        fmt.Printf("%s = %q\n", prefix, t)
+    default:
+        fmt.Printf("Unhandled: %T\n", t)
+    }
+}
+
+func main() { 
+     var pj interface{};
+     dat, err := ioutil.ReadFile("test.json")
+     check(err)
+     err = json.Unmarshal(dat, &pj)
+     check(err)
+     c, _, err := zk.Connect([]string{"127.0.0.1"}, time.Second) //*10)
+     check(err)
+     parsejson("", pj, c)
+}

--- a/integration/zookeeper/test.json
+++ b/integration/zookeeper/test.json
@@ -1,0 +1,25 @@
+{
+   "key": "foobar",
+   "database" : {
+        "host": "127.0.0.1",
+        "password": "p@sSw0rd",
+        "port": "3306",
+        "username": "confd"
+        },
+    "upstream" : {
+        "app1": "10.0.1.10:8080",
+        "app2": "10.0.1.11:8080"
+        },
+     "prefix": {
+        "database": {
+            "host": "127.0.0.1",
+            "password": "p@sSw0rd",
+            "port": "3306",
+            "username": "confd"
+            },
+            "upstream" : {
+                "app1": "10.0.1.10:8080",
+                "app2": "10.0.1.11:8080"
+                }
+            }
+}

--- a/integration/zookeeper/test.sh
+++ b/integration/zookeeper/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# feed zookeeper
+export ZK_PATH="`dirname \"$0\"`"
+sh -c "cd $ZK_PATH ; go run main.go"
+
+# Run confd
+./confd -verbose -debug -watch -confdir ./integration/confdir -backend zookeeper -node 127.0.0.1:2181
+if [ $? -eq 1 ]
+then
+   echo good
+else
+   echo "watch blackhole spotted. Did you fix it ?"
+fi
+./confd -verbose -debug -confdir ./integration/confdir -interval 5 -backend zookeeper -node 127.0.0.1:2181
+


### PR DESCRIPTION
  * watch is not yet supported - see backends/zookeeper/client.go for details
  * integration should work
  * add a simple example in quickstart guide
  * exit if watch is enabled when zookeeper is defined as backend

Tested with go 1.4