### PR TITLE
Added jsonGet support to template_funcs

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -158,6 +158,20 @@ val: {{.}}
 {{end}}
 ```
 
+### jsonGet
+
+Returns an interface{} from a property within a json object such as `{"animals": [{"type": "dog", "name": "Fido"}, {"type: "cat:, "name": "Misse"}]}`.
+
+```
+{{jsonGet (getv "/test/data/") "animals.0.name"}}
+{{ $animal := jsonGet (getv "/test/data/") "animals.1"}}
+type: {{ $animal.type }}
+name: {{ $animal.name }}
+{{range jsonGet (getv "/test/data/") "animals.*.name"}}
+{{.}}
+{{end}}
+```
+
 ### ls
 
 Returns all subkeys, []string, where path matches its argument. Returns an empty list if path is not found.

--- a/resource/template/template_funcs.go
+++ b/resource/template/template_funcs.go
@@ -2,8 +2,10 @@ package template
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -14,6 +16,7 @@ func newFuncMap() map[string]interface{} {
 	m["split"] = strings.Split
 	m["json"] = UnmarshalJsonObject
 	m["jsonArray"] = UnmarshalJsonArray
+	m["jsonGet"] = JsonGet
 	m["dir"] = path.Dir
 	m["getenv"] = os.Getenv
 	m["join"] = strings.Join
@@ -37,4 +40,50 @@ func UnmarshalJsonArray(data string) ([]interface{}, error) {
 	var ret []interface{}
 	err := json.Unmarshal([]byte(data), &ret)
 	return ret, err
+}
+
+func JsonGet(data string, property string) (interface{}, error) {
+	var f interface{}
+	err := json.Unmarshal([]byte(data), &f)
+	if err != nil {
+		panic(err)
+	}
+
+	m := f.(map[string]interface{})
+	return getValue(m, strings.Split(property, "."))
+}
+
+func getValue(value interface{}, props []string) (val interface{}, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+	if len(props) == 0 {
+		return value, nil
+	}
+	first := props[0]
+	rest := props[1:]
+	switch vv := value.(type) {
+	case map[string]interface{}:
+		v := value.(map[string]interface{})[first]
+		return getValue(v, rest)
+	case []interface{}:
+		values := value.([]interface{})
+		if first == "*" {
+			vs := make([]interface{}, len(values))
+			for i, v := range values {
+				vs[i], _ = getValue(v, rest)
+			}
+			return vs, nil
+		}
+		i, err := strconv.ParseInt(first, 10, 0)
+		if err != nil {
+			return nil, err
+		}
+		return getValue(values[i], rest)
+	default:
+		err := fmt.Errorf("Unsupported type: %v, for value: %#v", vv, value)
+		return value, err
+	}
 }

--- a/resource/template/template_test.go
+++ b/resource/template/template_test.go
@@ -206,6 +206,41 @@ ip: 192.168.10.12
 	},
 
 	templateTest{
+		desc: "jsonGet test",
+		toml: `
+[template]
+src = "test.conf.tmpl"
+dest = "./tmp/test.conf"
+keys = [
+    "/test/data/",
+]
+`,
+		tmpl: `
+{{jsonGet (getv "/test/data/") "animals.0.name"}}
+{{ $animal := jsonGet (getv "/test/data/") "animals.1"}}
+type: {{ $animal.type }}
+name: {{ $animal.name }}
+{{range jsonGet (getv "/test/data/") "animals.*.name"}}
+{{.}}
+{{end}}
+`,
+		expected: `
+Fido
+
+type: cat
+name: Misse
+
+Fido
+
+Misse
+
+`,
+		updateStore: func(tr *TemplateResource) {
+			tr.store.Set("/test/data/", `{"animals": [{"type": "dog", "name": "Fido"}, {"type": "cat", "name": "Misse"}]}`)
+		},
+	},
+
+	templateTest{
 		desc: "jsonArray test",
 		toml: `
 [template]


### PR DESCRIPTION
I added support for getting values for properties inside a JSON value.
I find it useful when I store large JSON structures.

Example from `docs/templates.md`
```
{{jsonGet (getv "/test/data/") "animals.0.name"}}
{{ $animal := jsonGet (getv "/test/data/") "animals.1"}}
type: {{ $animal.type }}
name: {{ $animal.name }}
{{range jsonGet (getv "/test/data/") "animals.*.name"}}
{{.}}
{{end}}
```