### PR TITLE
general integration test nitpicks

### DIFF
--- a/integration/consul/test.sh
+++ b/integration/consul/test.sh
@@ -9,4 +9,4 @@ curl -X PUT http://127.0.0.1:8500/v1/kv/upstream/app1 -d '10.0.1.10:8080'
 curl -X PUT http://127.0.0.1:8500/v1/kv/upstream/app2 -d '10.0.1.11:8080'
 
 # Run confd
-confd -onetime -verbose -confdir ./integration/confdir -backend consul -node "127.0.0.1:8500"
+confd -onetime -verbose -debug -confdir ./integration/confdir -backend consul -node 127.0.0.1:8500

--- a/integration/etcd/test.sh
+++ b/integration/etcd/test.sh
@@ -16,4 +16,4 @@ curl -L -X PUT http://127.0.0.1:4001/v2/keys/prefix/upstream/app2 -d value=10.0.
 
 
 # Run confd
-confd -onetime -verbose -debug -watch -confdir ./integration/confdir -backend etcd -node 127.0.0.1:4001
+confd -onetime -verbose -debug -confdir ./integration/confdir -backend etcd -node 127.0.0.1:4001 -watch

--- a/integration/redis/test.sh
+++ b/integration/redis/test.sh
@@ -14,5 +14,10 @@ redis-cli set /prefix/database/username confd
 redis-cli set /prefix/upstream/app1 10.0.1.10:8080
 redis-cli set /prefix/upstream/app2 10.0.1.11:8080
 
-# Run confd
+# Run confd with --watch, expecting it to fail
+confd -onetime -verbose -debug -confdir ./integration/confdir -interval 5 -backend redis -node 127.0.0.1:6379 -watch
+if [ $? -eq 0 ]
+then
+        exit 1
+fi
 confd -onetime -verbose -debug -confdir ./integration/confdir -interval 5 -backend redis -node 127.0.0.1:6379

--- a/integration/redis/test.sh
+++ b/integration/redis/test.sh
@@ -15,4 +15,4 @@ redis-cli set /prefix/upstream/app1 10.0.1.10:8080
 redis-cli set /prefix/upstream/app2 10.0.1.11:8080
 
 # Run confd
-confd -verbose -debug -onetime -confdir ./integration/confdir -interval 5 -backend redis -node 127.0.0.1:6379
+confd -onetime -verbose -debug -confdir ./integration/confdir -interval 5 -backend redis -node 127.0.0.1:6379

--- a/integration/zookeeper/test.sh
+++ b/integration/zookeeper/test.sh
@@ -4,13 +4,10 @@
 export ZK_PATH="`dirname \"$0\"`"
 sh -c "cd $ZK_PATH ; go run main.go"
 
-# Run confd
-./confd -verbose -debug -watch -confdir ./integration/confdir -backend zookeeper -node 127.0.0.1:2181
-if [ $? -eq 1 ]
+# Run confd with --watch, expecting it to fail
+confd -onetime -verbose -debug -confdir ./integration/confdir -interval 5 -backend zookeeper -node 127.0.0.1:2181 -watch
+if [ $? -eq 0 ]
 then
-   echo good
-else
-   echo "watch blackhole spotted. Did you fix it ?"
+        exit 1
 fi
-./confd -verbose -debug -confdir ./integration/confdir -interval 5 -backend zookeeper -node 127.0.0.1:2181
-
+confd -onetime -verbose -debug -confdir ./integration/confdir -interval 5 -backend zookeeper -node 127.0.0.1:2181


### PR DESCRIPTION
also includes an integration test for redis to ensure it fails when `-watch` is present