### PR TITLE
allow override of BIN_DIR

### DIFF
--- a/install
+++ b/install
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BIN_DIR=/usr/local/bin
+BIN_DIR=${BIN_DIR:-/usr/local/bin}
 INSTALL=install
 
 echo "Installing confd to $BIN_DIR/confd..."


### PR DESCRIPTION
This allows users to install confd to somewhere else rather than /usr/local/bin by overriding the envvar.

e.g.

```
$ BIN_DIR=~/bin ./install
Installing confd to /home/bacongobbler/bin/confd...
```