### PR TITLE
log that we're skipping config file to debug

### DIFF
--- a/config.go
+++ b/config.go
@@ -104,7 +104,7 @@ func initConfig() error {
 	}
 	// Update config from the TOML configuration file.
 	if configFile == "" {
-		log.Warning("Skipping confd config file.")
+		log.Debug("Skipping confd config file.")
 	} else {
 		log.Debug("Loading " + configFile)
 		configBytes, err := ioutil.ReadFile(configFile)


### PR DESCRIPTION
In recent versions of confd, this file is not necessary to run confd
as seen in the integration tests. This switches the log to debug as it's
still interesting information, but it's not necessary to log if we've
supplied the correct flagset to run confd without a config file.