### PR TITLE
add go 1.4 to travis.ci version matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go:
+  - 1.4
   - 1.3
   - 1.2
   - tip


### PR DESCRIPTION
`tip` and `1.4` may return the same build right now (using [`gimme`](https://github.com/meatballhat/gimme)), but this future-proofs the automated testing a bit. See http://docs.travis-ci.com/user/languages/go/#Specifying-a-Go-version-to-use for details.