### PR TITLE
Enable watch from the config file

### DIFF
--- a/confd.go
+++ b/confd.go
@@ -38,7 +38,7 @@ func main() {
 	errChan := make(chan error, 10)
 	var processor template.Processor
 	switch {
-	case watch:
+	case config.Watch:
 		processor = template.WatchProcessor(templateConfig, stopChan, doneChan, errChan)
 	default:
 		processor = template.IntervalProcessor(templateConfig, stopChan, doneChan, errChan, config.Interval)


### PR DESCRIPTION
Support enabling watch from either the command line or the config file.
 
This fixes #208.