### PR TITLE
Fix "The event in requested index is outdated and cleared" error

### DIFF
--- a/backends/etcd/client.go
+++ b/backends/etcd/client.go
@@ -77,13 +77,12 @@ func (c *Client) WatchPrefix(prefix string, waitIndex uint64, stopChan chan bool
 	resp, err := c.client.Watch(prefix, waitIndex+1, true, nil, stopChan)
 	if err != nil {
 		switch e := err.(type) {
-		default:
-			return waitIndex, err
 		case *goetcd.EtcdError:
 			if e.ErrorCode == 401 {
 				return 0, nil
 			}
 		}
+		return waitIndex, err
 	}
 	return resp.Node.ModifiedIndex, err
 }

--- a/backends/etcd/client.go
+++ b/backends/etcd/client.go
@@ -84,7 +84,6 @@ func (c *Client) WatchPrefix(prefix string, waitIndex uint64, stopChan chan bool
 				return 0, nil
 			}
 		}
-		return waitIndex, err
 	}
 	return resp.Node.ModifiedIndex, err
 }

--- a/backends/etcd/client.go
+++ b/backends/etcd/client.go
@@ -76,6 +76,14 @@ func (c *Client) WatchPrefix(prefix string, waitIndex uint64, stopChan chan bool
 	}
 	resp, err := c.client.Watch(prefix, waitIndex+1, true, nil, stopChan)
 	if err != nil {
+		switch e := err.(type) {
+		default:
+			return waitIndex, err
+		case *goetcd.EtcdError:
+			if e.ErrorCode == 401 {
+				return 0, nil
+			}
+		}
 		return waitIndex, err
 	}
 	return resp.Node.ModifiedIndex, err


### PR DESCRIPTION
Since the event history of etcd uses an (incorrectly implemented) cyclical buffer to store the event history, the history will periodically be wiped. When this happens, confd will go into an infinite loop with the following error

```
/opt/confd[20]: ERROR 401: The event in requested index is outdated and cleared (the requested history has been cleared [21424125/20199907]
```

The following code can be used to demonstrate the bug:
```go
package main

import (
  "fmt"
  "time"
  "github.com/coreos/go-etcd/etcd"
)

func main() {
  client := etcd.NewClient([]string{"http://127.0.0.1:4001"})

  var lastIndex uint64 = 0

  for {
    resp, err := client.Watch("/test", lastIndex, true, nil, nil)
    if err != nil {
      fmt.Printf("%#v\n", err)
      time.Sleep(1000 * time.Millisecond)
      // lastIndex = 0 // Uncomment to fix the error
      continue
    } else {
      fmt.Printf("%#v\n", resp)
      lastIndex = resp.EtcdIndex + 1
    }
    time.Sleep(5000 * time.Millisecond)
  }
}
```

Run the above program, and in another terminal the following command:
```sh
for i in `seq 1 1000`; do etcdctl set /test/hello $i > /dev/null; done
```

This pull-request fixes the bug by resetting the waitIndex when the error happens.
