### PR TITLE
allow ./build to be run directly from downloaded source packages...

### DIFF
--- a/build
+++ b/build
@@ -7,6 +7,12 @@ GO="godep go"
 ORG_PATH="github.com/kelseyhightower"
 REPO_PATH="${ORG_PATH}/confd"
 
+export GOPATH=${PWD}/gopath
+
+rm -f $GOPATH/src/${REPO_PATH}
+mkdir -p $GOPATH/src/${ORG_PATH}
+ln -s ${PWD} $GOPATH/src/${REPO_PATH}
+
 echo "Building confd..."
 # Static compilation is useful when confd is run in a container
 CGO_ENABLED=0 $GO build -a -installsuffix cgo -ldflags '-s' -o bin/confd ${REPO_PATH}

--- a/build
+++ b/build
@@ -7,7 +7,10 @@ GO="godep go"
 ORG_PATH="github.com/kelseyhightower"
 REPO_PATH="${ORG_PATH}/confd"
 
-export GOPATH=${PWD}/gopath
+SCRIPT=realpath $0
+SCRIPTPATH=dirname $SCRIPT
+
+export GOPATH=$SCRIPTPATH/gopath
 
 rm -f $GOPATH/src/${REPO_PATH}
 mkdir -p $GOPATH/src/${ORG_PATH}


### PR DESCRIPTION
...without cloning the code to $GOPATH/src.

this is done the same way as it is done in the etcd project.