### PR TITLE
template: don't crash on template error

### DIFF
--- a/resource/template/resource.go
+++ b/resource/template/resource.go
@@ -116,7 +116,11 @@ func (t *TemplateResource) createStageFile() error {
 	}
 	defer temp.Close()
 	log.Debug("Compiling source template " + t.Src)
-	tmpl := template.Must(template.New(path.Base(t.Src)).Funcs(t.funcMap).ParseFiles(t.Src))
+	tmpl, err := template.New(path.Base(t.Src)).Funcs(t.funcMap).ParseFiles(t.Src)
+	if err != nil {
+		return fmt.Errorf("Unable to process template %s, %s", t.Src, err)
+	}
+
 	if err = tmpl.Execute(temp, nil); err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently confd prints a stacktrace and exits when there is an error
processing a template.

Fix this issue by printing a error message instead of crashing. confd
will now resume processing other template resources.

Fixes #284