### PR TITLE
Use prefix instead of Prefix when monitoring changes.

### DIFF
--- a/src/github.com/kelseyhightower/confd/resource/template/processor.go
+++ b/src/github.com/kelseyhightower/confd/resource/template/processor.go
@@ -92,7 +92,7 @@ func (p *watchProcessor) Process() {
 func (p *watchProcessor) monitorPrefix(t *TemplateResource) {
 	defer p.wg.Done()
 	for {
-		index, err := t.storeClient.WatchPrefix(t.Prefix, t.lastIndex, p.stopChan)
+		index, err := t.storeClient.WatchPrefix(t.prefix, t.lastIndex, p.stopChan)
 		if err != nil {
 			p.errChan <- err
 			// Prevent backend errors from consuming all resources.


### PR DESCRIPTION
We never populate Prefix when creating a new templateResource, hence it's always empty when setting up a watch. I ran into this when I was trying to add support for watches with ZK backend.

I am not sure why we need Prefix in template to begin with (also it's confusing to have Prefix and prefix in the same struct), if you want I can refactor Prefix across the codebase.