### PR TITLE
Load AWS credentials through a provider chain

### DIFF
--- a/src/github.com/kelseyhightower/confd/backends/dynamodb/client.go
+++ b/src/github.com/kelseyhightower/confd/backends/dynamodb/client.go
@@ -20,7 +20,11 @@ type Client struct {
 // configured via the AWS_REGION environment variable.
 // It returns an error if the connection cannot be made or the table does not exist.
 func NewDynamoDBClient(table string) (*Client, error) {
-	creds := credentials.NewStaticCredentials("", "", "")
+	creds := credentials.NewChainCredentials(
+		[]credentials.Provider{
+			&credentials.EnvProvider{},
+			&credentials.EC2RoleProvider{},
+		})
 	_, err := creds.Get()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Confd 0.10.0 with a dynamodb backed always seems to fail with a  `FATAL EmptyStaticCreds: static credentials are empty error`.  Tried to set the credentials with both environmental variables and with a config file with no success. 

This seems to be because of [this line](https://github.com/kelseyhightower/confd/blob/master/src/github.com/kelseyhightower/confd/backends/dynamodb/client.go#L23) which only sets dummy, empty credentials. 

This patch replaces that with a [chain provider](https://github.com/kelseyhightower/confd/blob/master/vendor/src/github.com/awslabs/aws-sdk-go/aws/credentials/chain_provider.go) which looks at the [AWS environmental variables](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-environment) and at [EC2 provided roles](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).

Tried it with an actual dynamo table and it seems to work. No more errors and AWS credentials are loaded from environmental variables correctly.