### PR TITLE
Proposal feature: Allow templates to be sourced from backend

### DIFF
--- a/src/github.com/kelseyhightower/confd/resource/template/resource.go
+++ b/src/github.com/kelseyhightower/confd/resource/template/resource.go
@@ -112,11 +112,12 @@ func (t *TemplateResource) createStageFile() error {
 	var err error
 	if t.SrcKey != "" {
 		log.Debug("Using external source template key " + t.SrcKey)
-		result, err := t.storeClient.GetValues(appendPrefix(t.prefix, []string{t.SrcKey}))
+		fullKey := path.Join(t.prefix, t.SrcKey)
+		result, err := t.storeClient.GetValues([]string{fullKey})
 		if err != nil {
 			return err
 		}
-		src, ok := result[t.SrcKey]
+		src, ok := result[fullKey]
 		if !ok {
 			return errors.New("Missing template: " + t.SrcKey)
 		}


### PR DESCRIPTION
Allow confd to source the templates from the configured backend via a provided key.

Example:
* /etc/confd/conf.d/myconfig.toml
```
[template]
src_key = "/templates/myserviceconfig"
dest = "/etc/my/config.conf"
keys = [
    "/myapp/database/url",
    "/myapp/database/user",
]
```
* /templates/myserviceconfig key contents:
```
# confd generated config file
# from remote template
database_url = {{getv "/myapp/database/url"}}
database_user = {{getv "/myapp/database/user"}}
```

There are some different issues filed for creating dynamic configs, and I think this would help move towards supporting that. For my use case, I'd like to be able to update the sourced templates in `etcd` and have them propagate automatically. Without something like this I may have to orchestrate updating templates on a large number of servers.