### PR TITLE
Proposal feature: Support multiple template resources per file

### DIFF
--- a/src/github.com/kelseyhightower/confd/resource/template/processor.go
+++ b/src/github.com/kelseyhightower/confd/resource/template/processor.go
@@ -124,7 +124,7 @@ func getTemplateResources(config Config) ([]*TemplateResource, error) {
 			lastError = err
 			continue
 		}
-		templates = append(templates, t)
+		templates = append(templates, t...)
 	}
 	return templates, lastError
 }

--- a/src/github.com/kelseyhightower/confd/resource/template/resource.go
+++ b/src/github.com/kelseyhightower/confd/resource/template/resource.go
@@ -31,7 +31,7 @@ type Config struct {
 
 // TemplateResourceConfig holds the parsed template resource.
 type TemplateResourceConfig struct {
-	TemplateResources []TemplateResource `toml:"template"`
+	TemplateResources []*TemplateResource `toml:"template"`
 }
 
 // TemplateResource is the representation of a parsed template resource.
@@ -82,7 +82,7 @@ func NewTemplateResource(path string, config Config) ([]*TemplateResource, error
 			return nil, ErrEmptySrc
 		}
 		tr.Src = filepath.Join(config.TemplateDir, tr.Src)
-		templates = append(templates, &tr)
+		templates = append(templates, tr)
 	}
 	return templates, nil
 }

--- a/src/github.com/kelseyhightower/confd/resource/template/resource.go
+++ b/src/github.com/kelseyhightower/confd/resource/template/resource.go
@@ -31,7 +31,7 @@ type Config struct {
 
 // TemplateResourceConfig holds the parsed template resource.
 type TemplateResourceConfig struct {
-	TemplateResource TemplateResource `toml:"template"`
+	TemplateResources []TemplateResource `toml:"template"`
 }
 
 // TemplateResource is the representation of a parsed template resource.
@@ -59,7 +59,7 @@ type TemplateResource struct {
 var ErrEmptySrc = errors.New("empty src template")
 
 // NewTemplateResource creates a TemplateResource.
-func NewTemplateResource(path string, config Config) (*TemplateResource, error) {
+func NewTemplateResource(path string, config Config) ([]*TemplateResource, error) {
 	if config.StoreClient == nil {
 		return nil, errors.New("A valid StoreClient is required.")
 	}
@@ -69,19 +69,22 @@ func NewTemplateResource(path string, config Config) (*TemplateResource, error) 
 	if err != nil {
 		return nil, fmt.Errorf("Cannot process template resource %s - %s", path, err.Error())
 	}
-	tr := tc.TemplateResource
-	tr.keepStageFile = config.KeepStageFile
-	tr.noop = config.Noop
-	tr.storeClient = config.StoreClient
-	tr.funcMap = newFuncMap()
-	tr.store = memkv.New()
-	addFuncs(tr.funcMap, tr.store.FuncMap)
-	tr.prefix = filepath.Join("/", config.Prefix, tr.Prefix)
-	if tr.Src == "" {
-		return nil, ErrEmptySrc
+	var templates []*TemplateResource
+	for _, tr := range tc.TemplateResources {
+		tr.keepStageFile = config.KeepStageFile
+		tr.noop = config.Noop
+		tr.storeClient = config.StoreClient
+		tr.funcMap = newFuncMap()
+		tr.store = memkv.New()
+		addFuncs(tr.funcMap, tr.store.FuncMap)
+		tr.prefix = filepath.Join("/", config.Prefix, tr.Prefix)
+		if tr.Src == "" {
+			return nil, ErrEmptySrc
+		}
+		tr.Src = filepath.Join(config.TemplateDir, tr.Src)
+		templates = append(templates, &tr)
 	}
-	tr.Src = filepath.Join(config.TemplateDir, tr.Src)
-	return &tr, nil
+	return templates, nil
 }
 
 // setVars sets the Vars for template resource.


### PR DESCRIPTION
This will break the template config syntax, so it may be necessary to alter in some way to provide backwards compatibility. That being said, this PR would allow for a single Template Resource Config file to contain multiple template definitions.

* Use case(s):
This would allow for the dynamic generation of confd templates in the following manner
**Example**: Initial confd template resouce is defined, which then dynamically creates a second confd resource template based on data retrieved from backend.

**/etc/confd/conf.d/default.toml**
```
[[template]]
src = "nginx.toml.tmpl"
dest = "/etc/confd/conf.d/nginx.toml"
keys = [
    "/nginx/",
]
```
**/etc/confd/templates/nginx.toml.tmpl**
```
# In this example, every domain configured under "/nginx/*" gets its own config file.
{{range gets "/nginx/*}}
{{$data := json .Value}}
[[template]]
src = "nginx.conf.tmpl"
dest = "/etc/nginx/conf.d/{{$data.domain}}.conf"
keys = [
    "/nginx/{{$data.domain}}/",
    "/other/path/{{$data.other}}/",
]
{{end}}
```
I've left out the final `nginx.conf.tmpl`, that would be a standard confd template used to generate a single `nginx/conf.d/$domain.conf` file in this example.

I think this could solve for #310 and #256 (and other dynamic-config generation use cases) in a clean manner.
