### PR TITLE
Fix doc to use UID/GID instead of owner/group

### DIFF
--- a/docs/template-resources.md
+++ b/docs/template-resources.md
@@ -13,7 +13,8 @@ Template resources are stored under the `/etc/confd/conf.d` directory by default
 
 * `group` (string) - The group name that should own the file.
 * `mode` (string) - The permission mode of the file.
-* `owner` (string) - The username that should own the file.
+* `uid` (int) - The uid of the file.
+* `gid` (int) - The gid of the file.
 * `reload_cmd` (string) - The command to reload config.
 * `check_cmd` (string) - The command to check config. Use `{{.src}}` to reference the rendered source template.
 * `prefix` (string) - The string to prefix to keys.
@@ -24,8 +25,8 @@ Template resources are stored under the `/etc/confd/conf.d` directory by default
 [template]
 src = "nginx.conf.tmpl"
 dest = "/etc/nginx/nginx.conf"
-owner = "root"
-group = "root"
+uid = 33
+gid = 33
 mode = "0644"
 keys = [
   "/nginx",


### PR DESCRIPTION
only uid and gid are implemented right now so I've changed the doc accordingly