### PR TITLE
Add IP lookup template function

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -80,6 +80,15 @@ export HOSTNAME=`hostname`
 hostname: {{getenv "HOSTNAME"}}
 ```
 
+### getips
+
+Alias for net.LookupIP
+Uses local resolver to resolve a host. Returns a list of all IPv4 and IPv6 IP Addresses. Returns an error if host not found.
+
+```
+IPS: {{getips "www.example.com"}}
+```
+
 ### datetime
 
 Alias for time.Now

--- a/src/github.com/kelseyhightower/confd/resource/template/template_funcs.go
+++ b/src/github.com/kelseyhightower/confd/resource/template/template_funcs.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"encoding/json"
+	"net"
 	"os"
 	"path"
 	"strings"
@@ -22,6 +23,7 @@ func newFuncMap() map[string]interface{} {
 	m["toLower"] = strings.ToLower
 	m["contains"] = strings.Contains
 	m["replace"] = strings.Replace
+	m["getips"] = net.LookupIP
 	return m
 }
 


### PR DESCRIPTION
This PR adds a template function that aliases net.LookupIP. This
is helpful in situations where you need to know an IP with the environment
backend and do not know IP info ahead of time.