### PR TITLE
Allow proper use of etcd proxies.

### DIFF
--- a/src/github.com/kelseyhightower/confd/backends/client.go
+++ b/src/github.com/kelseyhightower/confd/backends/client.go
@@ -36,7 +36,7 @@ func New(config Config) (StoreClient, error) {
 	case "etcd":
 		// Create the etcd client upfront and use it for the life of the process.
 		// The etcdClient is an http.Client and designed to be reused.
-		return etcd.NewEtcdClient(backendNodes, config.ClientCert, config.ClientKey, config.ClientCaKeys, config.NoDiscover)
+		return etcd.NewEtcdClient(backendNodes, config.ClientCert, config.ClientKey, config.ClientCaKeys, config.NoSync)
 	case "zookeeper":
 		return zookeeper.NewZookeeperClient(backendNodes)
 	case "redis":

--- a/src/github.com/kelseyhightower/confd/backends/client.go
+++ b/src/github.com/kelseyhightower/confd/backends/client.go
@@ -36,7 +36,7 @@ func New(config Config) (StoreClient, error) {
 	case "etcd":
 		// Create the etcd client upfront and use it for the life of the process.
 		// The etcdClient is an http.Client and designed to be reused.
-		return etcd.NewEtcdClient(backendNodes, config.ClientCert, config.ClientKey, config.ClientCaKeys)
+		return etcd.NewEtcdClient(backendNodes, config.ClientCert, config.ClientKey, config.ClientCaKeys, config.NoDiscover)
 	case "zookeeper":
 		return zookeeper.NewZookeeperClient(backendNodes)
 	case "redis":

--- a/src/github.com/kelseyhightower/confd/backends/config.go
+++ b/src/github.com/kelseyhightower/confd/backends/config.go
@@ -7,6 +7,7 @@ type Config struct {
 	ClientCert   string
 	ClientKey    string
 	BackendNodes []string
+	NoDiscover   bool
 	Scheme       string
 	Table        string
 }

--- a/src/github.com/kelseyhightower/confd/backends/config.go
+++ b/src/github.com/kelseyhightower/confd/backends/config.go
@@ -7,7 +7,7 @@ type Config struct {
 	ClientCert   string
 	ClientKey    string
 	BackendNodes []string
-	NoDiscover   bool
+	NoSync       bool
 	Scheme       string
 	Table        string
 }

--- a/src/github.com/kelseyhightower/confd/backends/etcd/client.go
+++ b/src/github.com/kelseyhightower/confd/backends/etcd/client.go
@@ -15,7 +15,7 @@ type Client struct {
 
 // NewEtcdClient returns an *etcd.Client with a connection to named machines.
 // It returns an error if a connection to the cluster cannot be made.
-func NewEtcdClient(machines []string, cert, key string, caCert string, noDiscover bool) (*Client, error) {
+func NewEtcdClient(machines []string, cert, key string, caCert string, noSync bool) (*Client, error) {
 	var c *goetcd.Client
 	var err error
 	machines = prependSchemeToMachines(machines)
@@ -30,8 +30,8 @@ func NewEtcdClient(machines []string, cert, key string, caCert string, noDiscove
 	// Configure the DialTimeout, since 1 second is often too short
 	c.SetDialTimeout(time.Duration(3) * time.Second)
 
-	// If noDiscover is not set, we should locate the whole etcd cluster.
-	if !noDiscover {
+	// If noSync is not set, we should locate the whole etcd cluster.
+	if !noSync {
 		success := c.SetCluster(machines)
 		if !success {
 			return &Client{c}, errors.New("cannot connect to etcd cluster: " + strings.Join(machines, ","))

--- a/src/github.com/kelseyhightower/confd/backends/etcd/client.go
+++ b/src/github.com/kelseyhightower/confd/backends/etcd/client.go
@@ -18,6 +18,7 @@ type Client struct {
 func NewEtcdClient(machines []string, cert, key string, caCert string, noDiscover bool) (*Client, error) {
 	var c *goetcd.Client
 	var err error
+	machines = prependSchemeToMachines(machines)
 	if cert != "" && key != "" {
 		c, err = goetcd.NewTLSClient(machines, cert, key, caCert)
 		if err != nil {

--- a/src/github.com/kelseyhightower/confd/backends/etcd/client.go
+++ b/src/github.com/kelseyhightower/confd/backends/etcd/client.go
@@ -1,8 +1,8 @@
 package etcd
 
 import (
-	//"errors"
-	//"strings"
+	"errors"
+	"strings"
 	"time"
 
 	goetcd "github.com/coreos/go-etcd/etcd"
@@ -15,7 +15,7 @@ type Client struct {
 
 // NewEtcdClient returns an *etcd.Client with a connection to named machines.
 // It returns an error if a connection to the cluster cannot be made.
-func NewEtcdClient(machines []string, cert, key string, caCert string) (*Client, error) {
+func NewEtcdClient(machines []string, cert, key string, caCert string, noDiscover bool) (*Client, error) {
 	var c *goetcd.Client
 	var err error
 	if cert != "" && key != "" {
@@ -28,11 +28,14 @@ func NewEtcdClient(machines []string, cert, key string, caCert string) (*Client,
 	}
 	// Configure the DialTimeout, since 1 second is often too short
 	c.SetDialTimeout(time.Duration(3) * time.Second)
-	/*success := c.SetCluster(machines)
-	if !success {
-		return &Client{c}, errors.New("cannot connect to etcd cluster: " + strings.Join(machines, ","))
+
+	// If noDiscover is not set, we should locate the whole etcd cluster.
+	if !noDiscover {
+		success := c.SetCluster(machines)
+		if !success {
+			return &Client{c}, errors.New("cannot connect to etcd cluster: " + strings.Join(machines, ","))
+		}
 	}
-	*/
 	return &Client{c}, nil
 }
 

--- a/src/github.com/kelseyhightower/confd/backends/etcd/client.go
+++ b/src/github.com/kelseyhightower/confd/backends/etcd/client.go
@@ -1,8 +1,8 @@
 package etcd
 
 import (
-	"errors"
-	"strings"
+	//"errors"
+	//"strings"
 	"time"
 
 	goetcd "github.com/coreos/go-etcd/etcd"
@@ -28,10 +28,11 @@ func NewEtcdClient(machines []string, cert, key string, caCert string) (*Client,
 	}
 	// Configure the DialTimeout, since 1 second is often too short
 	c.SetDialTimeout(time.Duration(3) * time.Second)
-	success := c.SetCluster(machines)
+	/*success := c.SetCluster(machines)
 	if !success {
 		return &Client{c}, errors.New("cannot connect to etcd cluster: " + strings.Join(machines, ","))
 	}
+	*/
 	return &Client{c}, nil
 }
 

--- a/src/github.com/kelseyhightower/confd/backends/etcd/util.go
+++ b/src/github.com/kelseyhightower/confd/backends/etcd/util.go
@@ -1,0 +1,23 @@
+package etcd
+
+import "net/url"
+
+// prependScheme adds http:// to the front of URLs if no scheme is provided.
+func prependSchemeToMachines(machines []string) []string {
+	fixedmachines := make([]string, 0)
+
+	for _, machine := range machines {
+		u, err := url.Parse(machine)
+		if err != nil {
+			panic(err)
+		}
+
+		if u.Scheme == "" {
+			u.Scheme = "http"
+		}
+
+		fixedmachines = append(fixedmachines, u.String())
+	}
+
+	return fixedmachines
+}

--- a/src/github.com/kelseyhightower/confd/config.go
+++ b/src/github.com/kelseyhightower/confd/config.go
@@ -32,6 +32,7 @@ var (
 	logLevel          string
 	nodes             Nodes
 	noop              bool
+	noDiscover        bool
 	onetime           bool
 	prefix            string
 	printVersion      bool
@@ -54,6 +55,7 @@ type Config struct {
 	ConfDir      string   `toml:"confdir"`
 	Interval     int      `toml:"interval"`
 	Noop         bool     `toml:"noop"`
+	NoDiscover   bool     `toml:"no_discover"`
 	Prefix       string   `toml:"prefix"`
 	SRVDomain    string   `toml:"srv_domain"`
 	Scheme       string   `toml:"scheme"`
@@ -75,6 +77,7 @@ func init() {
 	flag.StringVar(&logLevel, "log-level", "", "level which confd should log messages")
 	flag.Var(&nodes, "node", "list of backend nodes")
 	flag.BoolVar(&noop, "noop", false, "only show pending changes")
+	flag.BoolVar(&noDiscover, "no-discover", false, "do not discover extra nodes (etcd backend only)")
 	flag.BoolVar(&onetime, "onetime", false, "run once and exit")
 	flag.StringVar(&prefix, "prefix", "/", "key path prefix")
 	flag.BoolVar(&printVersion, "version", false, "print version and exit")
@@ -181,6 +184,7 @@ func initConfig() error {
 		ClientCert:   config.ClientCert,
 		ClientKey:    config.ClientKey,
 		BackendNodes: config.BackendNodes,
+		NoDiscover:   config.NoDiscover,
 		Scheme:       config.Scheme,
 		Table:        config.Table,
 	}
@@ -254,6 +258,8 @@ func setConfigFromFlag(f *flag.Flag) {
 		config.Interval = interval
 	case "noop":
 		config.Noop = noop
+	case "no-discover":
+		config.NoDiscover = noDiscover
 	case "prefix":
 		config.Prefix = prefix
 	case "scheme":

--- a/src/github.com/kelseyhightower/confd/config.go
+++ b/src/github.com/kelseyhightower/confd/config.go
@@ -32,7 +32,7 @@ var (
 	logLevel          string
 	nodes             Nodes
 	noop              bool
-	noDiscover        bool
+	noSync            bool
 	onetime           bool
 	prefix            string
 	printVersion      bool
@@ -55,7 +55,7 @@ type Config struct {
 	ConfDir      string   `toml:"confdir"`
 	Interval     int      `toml:"interval"`
 	Noop         bool     `toml:"noop"`
-	NoDiscover   bool     `toml:"no_discover"`
+	NoSync       bool     `toml:"no_sync"`
 	Prefix       string   `toml:"prefix"`
 	SRVDomain    string   `toml:"srv_domain"`
 	Scheme       string   `toml:"scheme"`
@@ -77,7 +77,7 @@ func init() {
 	flag.StringVar(&logLevel, "log-level", "", "level which confd should log messages")
 	flag.Var(&nodes, "node", "list of backend nodes")
 	flag.BoolVar(&noop, "noop", false, "only show pending changes")
-	flag.BoolVar(&noDiscover, "no-discover", false, "do not discover extra nodes (etcd backend only)")
+	flag.BoolVar(&noSync, "no-sync", false, "do not discover extra nodes (etcd backend only)")
 	flag.BoolVar(&onetime, "onetime", false, "run once and exit")
 	flag.StringVar(&prefix, "prefix", "/", "key path prefix")
 	flag.BoolVar(&printVersion, "version", false, "print version and exit")
@@ -184,7 +184,7 @@ func initConfig() error {
 		ClientCert:   config.ClientCert,
 		ClientKey:    config.ClientKey,
 		BackendNodes: config.BackendNodes,
-		NoDiscover:   config.NoDiscover,
+		NoSync:       config.NoSync,
 		Scheme:       config.Scheme,
 		Table:        config.Table,
 	}
@@ -258,8 +258,8 @@ func setConfigFromFlag(f *flag.Flag) {
 		config.Interval = interval
 	case "noop":
 		config.Noop = noop
-	case "no-discover":
-		config.NoDiscover = noDiscover
+	case "no-sync":
+		config.NoSync = noSync
 	case "prefix":
 		config.Prefix = prefix
 	case "scheme":

--- a/src/github.com/kelseyhightower/confd/config_test.go
+++ b/src/github.com/kelseyhightower/confd/config_test.go
@@ -18,6 +18,7 @@ func TestInitConfigDefaultConfig(t *testing.T) {
 		ConfDir:      "/etc/confd",
 		Interval:     600,
 		Noop:         false,
+		NoDiscover:   false,
 		Prefix:       "/",
 		SRVDomain:    "",
 		Scheme:       "http",

--- a/src/github.com/kelseyhightower/confd/config_test.go
+++ b/src/github.com/kelseyhightower/confd/config_test.go
@@ -18,7 +18,7 @@ func TestInitConfigDefaultConfig(t *testing.T) {
 		ConfDir:      "/etc/confd",
 		Interval:     600,
 		Noop:         false,
-		NoDiscover:   false,
+		NoSync:       false,
 		Prefix:       "/",
 		SRVDomain:    "",
 		Scheme:       "http",


### PR DESCRIPTION
Resolves #319.

This pull request adds a `--no-discover` flag that applies only when using the etcd backend. This flag prevents confd from discovering the whole cluster, and so ensures that it only uses the proxy.

This change may be incomplete: right now with the change in this form you need to provide the etcd authority in the form `http://host:port` when using the `--no-discover` flag. If that's problematic, we can copy go-etcd's `Client.createHttpPath` method, which can add a scheme to the front of the authority if needed. Thoughts?