### PR TITLE
add ability to define dynamic template resource files

### DIFF
--- a/src/github.com/kelseyhightower/confd/resource/template/processor.go
+++ b/src/github.com/kelseyhightower/confd/resource/template/processor.go
@@ -2,9 +2,9 @@ package template
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
-	"strings"
 
 	"github.com/kelseyhightower/confd/log"
 )
@@ -134,7 +134,7 @@ func getTemplateResources(config Config) ([]*TemplateResource, error) {
 	if err == nil {
 		for k, v := range result {
 			log.Info("dynamic key: " + k + " / " + v)
-			t, err := NewTemplateResource(config.ConfigDir + "/" + v, config)
+			t, err := NewTemplateResource(config.ConfigDir+"/"+v, config)
 			if err != nil {
 				lastError = err
 				continue
@@ -142,7 +142,8 @@ func getTemplateResources(config Config) ([]*TemplateResource, error) {
 
 			split := strings.Split(k, "/")
 			key := "/" + split[len(split)-1]
-			t.Dest = strings.Replace(t.Dest,"{{.token}}",key, 1)
+			t.Dest = strings.Replace(t.Dest, "{{.token}}", key, 1)
+			t.ReloadCmd = strings.Replace(t.ReloadCmd, "{{.token}}", key, 1)
 			t.Prefix = key
 			t.prefix = key
 			templates = append(templates, t)

--- a/src/github.com/kelseyhightower/confd/resource/template/processor.go
+++ b/src/github.com/kelseyhightower/confd/resource/template/processor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"time"
+	"strings"
 
 	"github.com/kelseyhightower/confd/log"
 )
@@ -126,5 +127,27 @@ func getTemplateResources(config Config) ([]*TemplateResource, error) {
 		}
 		templates = append(templates, t)
 	}
+
+	// get dynamic TemplateResources
+	log.Info("parse dynamic keys")
+	result, err := config.StoreClient.GetValues([]string{"_confd"})
+	if err == nil {
+		for k, v := range result {
+			log.Info("dynamic key: " + k + " / " + v)
+			t, err := NewTemplateResource(config.ConfigDir + "/" + v, config)
+			if err != nil {
+				lastError = err
+				continue
+			}
+
+			split := strings.Split(k, "/")
+			key := "/" + split[len(split)-1]
+			t.Dest = strings.Replace(t.Dest,"{{.token}}",key, 1)
+			t.Prefix = key
+			t.prefix = key
+			templates = append(templates, t)
+		}
+	}
+
 	return templates, lastError
 }


### PR DESCRIPTION
Here is a small piece of code that allows you to define template resource files based on arbitrary keys in etcd (or presumably whatever backend). Here is the general idea:

```
core@lb1 ~ $ ls /etc/confd/conf.d/
haproxy.tomld
core@lb1 ~ $ etcdctl ls /_confd
/_confd/0491f260-d089-4263-a7f7-74c0144b6874
/_confd/0491f260-d089-4263-a7f7-XXXXXXXXXXXXXX
core@lb1 ~ $ etcdctl get /_confd/0491f260-d089-4263-a7f7-74c0144b6874
haproxy.tomld
core@lb1 ~ $
```

We grab any values in /_confd, and source the specified resource template file (I appended mine with "d" to avoid complaints from the standard file parsing routine)

The only other thing that happens is the "dest" value does a simple token replacement based on the key entered in /_confd to allow you to specify the location / name of the destination config file. 

HAProxy example:

```
[template]
prefix = "/haproxy"
src = "haproxy.tmpl"
dest = "/home/core/{{.token}}.cnf"
owner = "core"
mode = "0644"
keys = [
  "/backend/primary",
  "/upstream",
]
check_cmd = "/usr/sbin/nginx -t -c {{.src}}"
reload_cmd = "/usr/sbin/service nginx reload"
```

I'm happy to change the defaults (_confd, or $token value) if this is something you'd like to merge, just let me know if it is worth taking time to clean up and run tests, etc!

thx