### PR TITLE
IP dns resolving function for templates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+bin
+vendor

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 bin
 vendor
+pkg

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,4 @@ RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
 ENV GOPATH /go
 ENV PATH /go/bin:$PATH
 WORKDIR /go
+RUN go get github.com/constabulary/gb/...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM gliderlabs/alpine:3.2
+MAINTAINER Jussi Nummelin <jussi.nummelin@gmail.com>
+RUN apk-install bash go bzr git mercurial subversion openssh-client ca-certificates
+
+RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
+ENV GOPATH /go
+ENV PATH /go/bin:$PATH
+WORKDIR /go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM gliderlabs/alpine:3.2
-MAINTAINER Jussi Nummelin <jussi.nummelin@gmail.com>
-RUN apk-install bash go bzr git mercurial subversion openssh-client ca-certificates
-
-RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
-ENV GOPATH /go
-ENV PATH /go/bin:$PATH
-WORKDIR /go
-RUN go get github.com/constabulary/gb/...

--- a/Dockerfile.build.alpine
+++ b/Dockerfile.build.alpine
@@ -1,0 +1,9 @@
+FROM gliderlabs/alpine:3.2
+MAINTAINER Jussi Nummelin <jussi.nummelin@gmail.com>
+RUN apk-install bash go bzr git mercurial subversion openssh-client ca-certificates
+
+RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
+ENV GOPATH /go
+ENV PATH /go/bin:$PATH
+WORKDIR /go
+RUN go get github.com/constabulary/gb/...

--- a/Dockerfile.build.alpine
+++ b/Dockerfile.build.alpine
@@ -5,5 +5,5 @@ RUN apk-install bash go bzr git mercurial subversion openssh-client ca-certifica
 RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
 ENV GOPATH /go
 ENV PATH /go/bin:$PATH
-WORKDIR /go
+WORKDIR /app
 RUN go get github.com/constabulary/gb/...

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,6 +23,16 @@ $ ./build
 $ sudo ./install
 ```
 
+#### Building from Source for Alpine Linux
+
+Since many people are using Alpine Linux as their base images for Docker there's support to build Alpine package also. Naturally by using Docker itself. :)
+
+```
+$ docker build -t confd_builder -f Dockerfile.build.alpine .
+$ docker run -ti -v $(pwd):/app confd_builder ./build
+```
+The above docker commands will produce binary in the local bin directory.
+
 ### Next Steps
 
 Get up and running with the [Quick Start Guide](quick-start-guide.md).

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -239,6 +239,16 @@ Alias for the strings.Join function.
 services: {{join $services ","}}
 ```
 
+### lookupIP
+
+Wrapper for net.LookupIP function. The wrapper also sorts (alphabeticaly) the IP addresses. This is crucial since in dynamic environments DNS servers typically shuffle the addresses linked to domain name. And that would cause unnecessary config reloads.
+
+```
+{{range lookupIP "some.host.local"}}
+    server {{.}};
+{{end}}
+```
+
 ## Example Usage
 
 ```Bash
@@ -380,4 +390,3 @@ server {
 ```
 
 Go's [`text/template`](http://golang.org/pkg/text/template/) package is very powerful. For more details on it's capabilities see its [documentation.](http://golang.org/pkg/text/template/)
-

--- a/src/github.com/kelseyhightower/confd/resource/template/template_funcs.go
+++ b/src/github.com/kelseyhightower/confd/resource/template/template_funcs.go
@@ -51,6 +51,7 @@ func LookupIP(data string) ([]string) {
 	if(err != nil) {
 		return nil
 	}
+	// "Cast" IPs into strings and sort the array
 	ipStrings := make([]string, len(ips))
 
 	for i, ip := range ips {

--- a/src/github.com/kelseyhightower/confd/resource/template/template_funcs.go
+++ b/src/github.com/kelseyhightower/confd/resource/template/template_funcs.go
@@ -6,6 +6,8 @@ import (
 	"path"
 	"strings"
 	"time"
+	"net"
+	"sort"
 )
 
 func newFuncMap() map[string]interface{} {
@@ -22,6 +24,7 @@ func newFuncMap() map[string]interface{} {
 	m["toLower"] = strings.ToLower
 	m["contains"] = strings.Contains
 	m["replace"] = strings.Replace
+	m["lookupIP"] = LookupIP
 	return m
 }
 
@@ -41,4 +44,18 @@ func UnmarshalJsonArray(data string) ([]interface{}, error) {
 	var ret []interface{}
 	err := json.Unmarshal([]byte(data), &ret)
 	return ret, err
+}
+
+func LookupIP(data string) ([]string) {
+	ips, err := net.LookupIP(data)
+	if(err != nil) {
+		return nil
+	}
+	ipStrings := make([]string, len(ips))
+
+	for i, ip := range ips {
+		ipStrings[i] = ip.String()
+	}
+	sort.Strings(ipStrings)
+	return ipStrings
 }

--- a/src/github.com/kelseyhightower/confd/resource/template/template_test.go
+++ b/src/github.com/kelseyhightower/confd/resource/template/template_test.go
@@ -369,6 +369,34 @@ dir: /test/data
 			tr.store.Set("/test/data/def", "child")
 		},
 	},
+	templateTest{
+		desc: "ip lookup test",
+		toml: `
+[template]
+src = "test.conf.tmpl"
+dest = "./tmp/test.conf"
+keys = [
+    "/test/data",
+    "/test/data/abc",
+]
+`,
+		tmpl: `
+{{range lookupIP "localhost"}}
+ip: {{.}}
+{{end}}
+`,
+		expected: `
+
+ip: 127.0.0.1
+
+ip: ::1
+
+`,
+		updateStore: func(tr *TemplateResource) {
+			tr.store.Set("/test/data", "parent")
+			tr.store.Set("/test/data/def", "child")
+		},
+	},
 }
 
 // TestTemplates runs all tests in templateTests


### PR DESCRIPTION
PR adds IP lookup function for templates. SImilar to #323 with small but significant difference. This version sorts the IP list so that unnecessary config reloads can be avoided. 

As we are using this on Docker and using Alpine as our base image there's also builder image for Alpine package building.