### PR TITLE
Add Rancher Metadata backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ before_install:
   - mkdir /tmp/dynamodb
   - wget -O - http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest | tar xz --directory /tmp/dynamodb
   - java -Djava.library.path=/tmp/dynamodb/DynamoDBLocal_lib -jar /tmp/dynamodb/DynamoDBLocal.jar -inMemory &
+  # Install rancher metadata
+  - wget https://github.com/rancher/rancher-metadata/releases/download/v0.1.0/rancher-metadata.tar.gz
+  - mkdir -p ./rancher-metadata
+  - tar xzf rancher-metadata.tar.gz --strip-components=1 -C ./rancher-metadata
+  - sudo mv ./rancher-metadata/bin/rancher-metadata /bin/
 install:
   - sudo pip install awscli
   - go get github.com/constabulary/gb/...
@@ -30,3 +35,4 @@ script:
   - bash integration/consul/test.sh
   - bash integration/etcd/test.sh
   - bash integration/redis/test.sh
+  - bash integration/rancher/test.sh

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -12,6 +12,7 @@ confd supports the following backends:
 * redis
 * zookeeper
 * dynamodb
+* rancher
 
 ### Add keys
 
@@ -75,6 +76,10 @@ aws dynamodb put-item --table-name <YOUR_TABLE> --region <YOUR_REGION> \
     --item '{ "key": { "S": "/myapp/database/user" }, "value": {"S": "rob"}}'
 ```
 
+#### rancher
+
+This backend consumes the Rancher Container Service metadata. For available keys see [rancher metadata docs](http://docs.rancher.com/rancher/metadata-service/)
+
 ### Create the confdir
 
 The confdir is where template resource configs and source templates are stored.
@@ -136,6 +141,14 @@ confd -onetime -backend dynamodb -table <YOUR_TABLE>
 ```
 confd -onetime -backend env
 ```
+
+#### rancher
+
+```
+confd -onetime -backend rancher -prefix /2015-07-25
+```
+
+*Note*: The metadata api prefix can be defined on the cli, or as part of your keys in the template toml file.
 
 Output:
 ```

--- a/integration/rancher/test.sh
+++ b/integration/rancher/test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+cat > /rancher-answers.json<<EOF
+{
+    "default": {
+        "key": "foobar",
+        "database": {
+           "host": "127.0.0.1",
+           "password": "p@sSw0rd",
+           "port": 3306,
+           "username": "confd"
+         },
+         "upstream": {
+           "app1": "10.0.1.10:8080",
+           "app2": "10.0.1.11:8080"
+         },
+         "prefix": {
+           "database": {
+              "host": "127.0.0.1",
+              "password": "p@sSw0rd",
+              "port": 3306,
+              "username": "confd"
+            },
+            "upstream": {
+              "app1": "10.0.1.10:8080",
+              "app2": "10.0.1.11:8080"
+            }
+         }    
+    }
+}
+EOF
+rancher-metadata -listen 127.0.0.1:8080 --answers /rancher-answers.json &
+
+confd --onetime --log-level debug --prefix /2015-07-25 --confdir ./integration/confdir --backend rancher --node 127.0.0.1:8080 --watch
+if [ $? -eq 0 ]
+then
+   exit 1
+fi
+
+confd --onetime --log-level debug --prefix /2015-07-25 --confdir ./integration/confdir --backend rancher --node 127.0.0.1:8080

--- a/integration/rancher/test.sh
+++ b/integration/rancher/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cat > /rancher-answers.json<<EOF
+cat > ./rancher-answers.json<<EOF
 {
     "default": {
         "key": "foobar",
@@ -29,7 +29,7 @@ cat > /rancher-answers.json<<EOF
     }
 }
 EOF
-rancher-metadata -listen 127.0.0.1:8080 --answers /rancher-answers.json &
+rancher-metadata -listen 127.0.0.1:8080 --answers ./rancher-answers.json &
 
 confd --onetime --log-level debug --prefix /2015-07-25 --confdir ./integration/confdir --backend rancher --node 127.0.0.1:8080 --watch
 if [ $? -eq 0 ]

--- a/src/github.com/kelseyhightower/confd/backends/client.go
+++ b/src/github.com/kelseyhightower/confd/backends/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kelseyhightower/confd/backends/dynamodb"
 	"github.com/kelseyhightower/confd/backends/env"
 	"github.com/kelseyhightower/confd/backends/etcd"
+	"github.com/kelseyhightower/confd/backends/rancher"
 	"github.com/kelseyhightower/confd/backends/redis"
 	"github.com/kelseyhightower/confd/backends/stackengine"
 	"github.com/kelseyhightower/confd/backends/zookeeper"
@@ -39,6 +40,8 @@ func New(config Config) (StoreClient, error) {
 		return etcd.NewEtcdClient(backendNodes, config.ClientCert, config.ClientKey, config.ClientCaKeys)
 	case "zookeeper":
 		return zookeeper.NewZookeeperClient(backendNodes)
+	case "rancher":
+		return rancher.NewRancherClient(backendNodes)
 	case "redis":
 		return redis.NewRedisClient(backendNodes)
 	case "env":

--- a/src/github.com/kelseyhightower/confd/backends/rancher/client.go
+++ b/src/github.com/kelseyhightower/confd/backends/rancher/client.go
@@ -1,0 +1,125 @@
+package rancher
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/kelseyhightower/confd/log"
+)
+
+const (
+	MetaDataURL = "http://rancher-metadata"
+)
+
+type Client struct {
+	url        string
+	httpClient *http.Client
+}
+
+func NewRancherClient(backendNodes []string) (*Client, error) {
+	url := MetaDataURL
+
+	if len(backendNodes) > 0 {
+		url = "http://" + backendNodes[0]
+	}
+
+	log.Info("Using Rancher Metadata URL: " + url)
+	client := &Client{
+		url:        url,
+		httpClient: &http.Client{},
+	}
+
+	err := client.testConnection()
+	return client, err
+
+}
+
+func (c *Client) GetValues(keys []string) (map[string]string, error) {
+	vars := map[string]string{}
+
+	for _, key := range keys {
+		body, err := c.makeMetaDataRequest(key)
+		if err != nil {
+			return vars, err
+		}
+
+		var jsonResponse interface{}
+		if err = json.Unmarshal(body, &jsonResponse); err != nil {
+			return vars, err
+		}
+
+		if err = treeWalk(key, jsonResponse, vars); err != nil {
+			return vars, err
+		}
+	}
+	return vars, nil
+}
+
+func treeWalk(root string, val interface{}, vars map[string]string) error {
+	switch val.(type) {
+	case map[string]interface{}:
+		for k := range val.(map[string]interface{}) {
+			treeWalk(strings.Join([]string{root, k}, "/"), val.(map[string]interface{})[k], vars)
+		}
+	case []interface{}:
+		for i, item := range val.([]interface{}) {
+			idx := strconv.Itoa(i)
+			if i, isMap := item.(map[string]interface{}); isMap {
+				if name, exists := i["name"]; exists {
+					idx = name.(string)
+				}
+			}
+
+			treeWalk(strings.Join([]string{root, idx}, "/"), item, vars)
+		}
+	case bool:
+		vars[root] = strconv.FormatBool(val.(bool))
+	case string:
+		vars[root] = val.(string)
+	case float64:
+		vars[root] = strconv.FormatFloat(val.(float64), 'f', -1, 64)
+	case nil:
+		vars[root] = "null"
+	default:
+		log.Error("Unknown type: " + reflect.TypeOf(val).Name())
+	}
+	return nil
+}
+
+func (c *Client) makeMetaDataRequest(path string) ([]byte, error) {
+	req, _ := http.NewRequest("GET", strings.Join([]string{c.url, path}, ""), nil)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return ioutil.ReadAll(resp.Body)
+}
+
+func (c *Client) testConnection() error {
+	var err error
+	maxTime := 20 * time.Second
+
+	for i := 1 * time.Second; i < maxTime; i *= time.Duration(2) {
+		if _, err = c.makeMetaDataRequest("/"); err != nil {
+			time.Sleep(i)
+		} else {
+			return nil
+		}
+	}
+	return err
+}
+
+func (c *Client) WatchPrefix(prefix string, waitIndex uint64, stopChan chan bool) (uint64, error) {
+	// Watches are not implemented in Rancher Metadata Service
+	<-stopChan
+	return 0, nil
+}

--- a/src/github.com/kelseyhightower/confd/config.go
+++ b/src/github.com/kelseyhightower/confd/config.go
@@ -162,6 +162,7 @@ func initConfig() error {
 			"zookeeper": true,
 			"redis":     true,
 			"dynamodb":  true,
+			"rancher":   true,
 		}
 
 		if unsupportedBackends[config.Backend] {


### PR DESCRIPTION
Inside a Rancher Container Service environment a user has access to a container metadata service that is similar to AWS style metadata. With this backend users can consume the data with confd.

This PR has the backend, updated docs, and integration tests. Hopefully I covered everything, but if not let me know and will add whatever is needed.

Thanks!