### PR TITLE
link to the right command-line-flags doc

### DIFF
--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -3,7 +3,7 @@
 The confd configuration file is written in [TOML](https://github.com/mojombo/toml)
 and loaded from `/etc/confd/confd.toml` by default. You can specify the config file via the `-config-file` command line flag.
 
-> Note: You can use confd without a configuration file. See [Command Line Flags](https://github.com/kelseyhightower/confd/wiki/Command-Line-Flags).
+> Note: You can use confd without a configuration file. See [Command Line Flags](https://github.com/kelseyhightower/confd/blob/master/docs/command-line-flags.md).
 
 Optional:
 


### PR DESCRIPTION
Passed by and noticed that the old link redirects to the projects github home page.