### PR TITLE
add support for dynamic keys, using environment variables

### DIFF
--- a/src/github.com/kelseyhightower/confd/resource/template/resource.go
+++ b/src/github.com/kelseyhightower/confd/resource/template/resource.go
@@ -70,6 +70,7 @@ func NewTemplateResource(path string, config Config) (*TemplateResource, error) 
 		return nil, fmt.Errorf("Cannot process template resource %s - %s", path, err.Error())
 	}
 	tr := tc.TemplateResource
+	tr.expandEnv()
 	tr.keepStageFile = config.KeepStageFile
 	tr.noop = config.Noop
 	tr.storeClient = config.StoreClient
@@ -284,4 +285,10 @@ func (t *TemplateResource) setFileMode() error {
 		t.FileMode = os.FileMode(mode)
 	}
 	return nil
+}
+
+func (t *TemplateResource) expandEnv() {
+	for i, key := range t.Keys {
+		t.Keys[i] = os.ExpandEnv(key)
+	}
 }


### PR DESCRIPTION
This is quick hack, based on the behavior described in #73 and #310.
Example / our use case:
```toml
[template]
src = "database.php.tmpl"
dest = "/var/www/site/application/config/database.php"
keys = [
    "/cluster/${CLUSTER_ID}/mysql/master/internal",
    "/cluster/${CLUSTER_ID}/mysql/slave/internal",
]
```
Template:
```php
<?php  if (!defined('BASEPATH')) exit('No direct script access allowed');

{{ $clusterID := getenv "CLUSTER_ID" }}

$db['default']['hostname'] = "{{ getv (printf "/cluster/%s/mysql/master/internal" $clusterID) }}"
// ...

$db['slave'] = $db['default'];
$db['slave']['hostname'] = "{{ getv (printf "/cluster/%s/mysql/slave/internal" $clusterID) }}"
?>
```