### PR TITLE
Add more debugging output for onetime and env.

### DIFF
--- a/src/github.com/kelseyhightower/confd/backends/env/client.go
+++ b/src/github.com/kelseyhightower/confd/backends/env/client.go
@@ -1,8 +1,11 @@
 package env
 
 import (
+	"fmt"
 	"os"
 	"strings"
+
+	"github.com/kelseyhightower/confd/log"
 )
 
 var replacer = strings.NewReplacer("/", "_")
@@ -32,6 +35,9 @@ func (c *Client) GetValues(keys []string) (map[string]string, error) {
 			}
 		}
 	}
+
+	log.Debug(fmt.Sprintf("Key Map: %#v", vars))
+
 	return vars, nil
 }
 

--- a/src/github.com/kelseyhightower/confd/confd.go
+++ b/src/github.com/kelseyhightower/confd/confd.go
@@ -32,7 +32,7 @@ func main() {
 	templateConfig.StoreClient = storeClient
 	if onetime {
 		if err := template.Process(templateConfig); err != nil {
-			os.Exit(1)
+			log.Fatal(err.Error())
 		}
 		os.Exit(0)
 	}

--- a/src/github.com/kelseyhightower/confd/resource/template/processor.go
+++ b/src/github.com/kelseyhightower/confd/resource/template/processor.go
@@ -118,7 +118,13 @@ func getTemplateResources(config Config) ([]*TemplateResource, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if len(paths) < 1 {
+		log.Warning("Found no templates")
+	}
+
 	for _, p := range paths {
+		log.Debug(fmt.Sprintf("Found template: %s", p))
 		t, err := NewTemplateResource(p, config)
 		if err != nil {
 			lastError = err


### PR DESCRIPTION
When setting up a new installation running in `onetime` mode and using the `env` backend I ran into a number of issues that produced no error or debugging output. I ended up modifying the code to tell me what's happening. This PR add some more logging in areas where you are currently blind and hopefully will benefit anyone else facing a similar issue.