### PR TITLE
add support for the -scheme commandline flag with etcd

### DIFF
--- a/config.go
+++ b/config.go
@@ -153,20 +153,23 @@ func initConfig() error {
 	if config.Backend == "etcd" {
 		var machines []string
 		for _, node := range config.BackendNodes {
-			uri := strings.Split(node, ":")
-			host := uri[0]
-			port := "4001"
-			if len(uri) > 1 {
-				port = uri[1]
+			if !strings.HasPrefix(node, "http") {
+				node = config.Scheme + "://" + node
 			}
-			u, err := url.Parse(host)
+			u, err := url.Parse(node)
 			if err != nil {
 				return err
 			}
+			host, port, err := net.SplitHostPort(u.Host)
+			if err != nil {
+				host = u.Host
+				port = "4001"
+			}
+
 			if u.Scheme == "" {
 				u.Scheme = config.Scheme
 			}
-			machines = append(machines, fmt.Sprintf("%s:%s", u.String(), port))
+			machines = append(machines, u.Scheme+"://"+net.JoinHostPort(host, port))
 		}
 		config.BackendNodes = machines
 	}

--- a/config.go
+++ b/config.go
@@ -153,14 +153,20 @@ func initConfig() error {
 	if config.Backend == "etcd" {
 		var machines []string
 		for _, node := range config.BackendNodes {
-			u, err := url.Parse(strings.Split(node, ":")[0])
+			uri := strings.Split(node, ":")
+			host := uri[0]
+			port := "4001"
+			if len(uri) > 1 {
+				port = uri[1]
+			}
+			u, err := url.Parse(host)
 			if err != nil {
 				return err
 			}
 			if u.Scheme == "" {
 				u.Scheme = config.Scheme
 			}
-			machines = append(machines, fmt.Sprintf("%s:%s", u.String(), strings.Split(node, ":")[1]))
+			machines = append(machines, fmt.Sprintf("%s:%s", u.String(), port))
 		}
 		config.BackendNodes = machines
 	}


### PR DESCRIPTION
Examples:
```
confd
2016-02-21T14:35:29+01:00 rkaufmann confd[11784]: INFO Backend set to etcd
2016-02-21T14:35:29+01:00 rkaufmann confd[11784]: INFO Starting confd
2016-02-21T14:35:29+01:00 rkaufmann confd[11784]: INFO Backend nodes set to http://127.0.0.1:4001
```

```
confd -scheme https                                                                                                                                          :(
2016-02-21T14:39:11+01:00 rkaufmann confd[12162]: INFO Backend set to etcd
2016-02-21T14:39:11+01:00 rkaufmann confd[12162]: INFO Starting confd
2016-02-21T14:39:11+01:00 rkaufmann confd[12162]: INFO Backend nodes set to https://127.0.0.1:4001
```

```
confd -node localhost -node 192.168.0.11:4002 -scheme https
2016-02-21T14:56:30+01:00 rkaufmann confd[14663]: INFO Backend set to etcd
2016-02-21T14:56:30+01:00 rkaufmann confd[14663]: INFO Starting confd
2016-02-21T14:56:30+01:00 rkaufmann confd[14663]: INFO Backend nodes set to https://localhost:4001, https://192.168.0.11:4002
```