### PR TITLE
updated Dockerfile.build.alpine

### DIFF
--- a/Dockerfile.build.alpine
+++ b/Dockerfile.build.alpine
@@ -1,5 +1,4 @@
 FROM alpine:3.3
-MAINTAINER Rene Kaufmann <kaufmann.r@gmail.com>
 
 ENV GOPATH /go
 ENV GO15VENDOREXPERIMENT 1

--- a/Dockerfile.build.alpine
+++ b/Dockerfile.build.alpine
@@ -1,9 +1,13 @@
-FROM gliderlabs/alpine:3.2
-MAINTAINER Jussi Nummelin <jussi.nummelin@gmail.com>
-RUN apk-install bash go bzr git mercurial subversion openssh-client ca-certificates
+FROM alpine:3.3
+MAINTAINER Rene Kaufmann <kaufmann.r@gmail.com>
 
-RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
 ENV GOPATH /go
-ENV PATH /go/bin:$PATH
+ENV GO15VENDOREXPERIMENT 1
+
+RUN mkdir -p "$GOPATH/src/" "$GOPATH/bin" && chmod -R 777 "$GOPATH" && \
+    mkdir -p /go/src/github.com/kelseyhightower/confd
+
+RUN apk --update add go bash && \
+    ln -s /go/src/github.com/kelseyhightower/confd /app
+
 WORKDIR /app
-RUN go get github.com/constabulary/gb/...

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,7 +29,7 @@ Since many people are using Alpine Linux as their base images for Docker there's
 
 ```
 $ docker build -t confd_builder -f Dockerfile.build.alpine .
-$ docker run -ti -v $(pwd):/app confd_builder ./build
+$ docker run -ti --rm -v $(pwd):/app confd_builder ./build
 ```
 The above docker commands will produce binary in the local bin directory.
 


### PR DESCRIPTION
the old Dockerfile was no longer working because of the switch to the go 1.6 vendoring support in favor of gb.