### PR TITLE
improved etcd watch support

### DIFF
--- a/backends/etcd/client.go
+++ b/backends/etcd/client.go
@@ -115,49 +115,65 @@ func nodeWalk(node *client.Node, vars map[string]string) error {
 	return nil
 }
 
+type watchResponse struct {
+	waitIndex uint64
+	err       error
+}
+
 func (c *Client) WatchPrefix(prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {
 	// return something > 0 to trigger a key retrieval from the store
 	if waitIndex == 0 {
 		return 1, nil
 	}
 
-	for {
-		// Setting AfterIndex to 0 (default) means that the Watcher
-		// should start watching for events starting at the current
-		// index, whatever that may be.
-		watcher := c.client.Watcher(prefix, &client.WatcherOptions{AfterIndex: uint64(0), Recursive: true})
-		ctx, cancel := context.WithCancel(context.Background())
-		cancelRoutine := make(chan bool)
-		defer close(cancelRoutine)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelRoutine := make(chan bool)
+	respChan := make(chan watchResponse)
+	defer close(cancelRoutine)
 
-		go func() {
+	go func() {
+		for {
 			select {
-			case <-stopChan:
-				cancel()
 			case <-cancelRoutine:
+				cancel()
 				return
-			}
-		}()
+			default:
+				// Setting AfterIndex to 0 (default) means that the Watcher
+				// should start watching for events starting at the current
+				// index, whatever that may be.
+				watcher := c.client.Watcher(prefix, &client.WatcherOptions{AfterIndex: uint64(0), Recursive: true})
+				resp, err := watcher.Next(ctx)
+				if err != nil {
+					switch e := err.(type) {
+					case *client.Error:
+						if e.Code == 401 {
+							respChan <- watchResponse{0, nil}
+							return
+						}
+					}
+					respChan <- watchResponse{waitIndex, err}
+					return
+				}
 
-		resp, err := watcher.Next(ctx)
-		if err != nil {
-			switch e := err.(type) {
-			case *client.Error:
-				if e.Code == 401 {
-					return 0, nil
+				// Only return if we have a key prefix we care about.
+				// This is not an exact match on the key so there is a chance
+				// we will still pickup on false positives. The net win here
+				// is reducing the scope of keys that can trigger updates.
+				for _, k := range keys {
+					if strings.HasPrefix(resp.Node.Key, k) {
+						respChan <- watchResponse{resp.Node.ModifiedIndex, err}
+						return
+					}
 				}
 			}
-			return waitIndex, err
 		}
-
-		// Only return if we have a key prefix we care about.
-		// This is not an exact match on the key so there is a chance
-		// we will still pickup on false positives. The net win here
-		// is reducing the scope of keys that can trigger updates.
-		for _, k := range keys {
-			if strings.HasPrefix(resp.Node.Key, k) {
-				return resp.Node.ModifiedIndex, err
-			}
+	}()
+	for {
+		select {
+		case <-stopChan:
+			return waitIndex, nil
+		case r := <-respChan:
+			return r.waitIndex, r.err
 		}
 	}
 }

--- a/backends/etcd/client.go
+++ b/backends/etcd/client.go
@@ -115,65 +115,49 @@ func nodeWalk(node *client.Node, vars map[string]string) error {
 	return nil
 }
 
-type watchResponse struct {
-	waitIndex uint64
-	err       error
-}
-
 func (c *Client) WatchPrefix(prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {
 	// return something > 0 to trigger a key retrieval from the store
 	if waitIndex == 0 {
 		return 1, nil
 	}
 
+	// Setting AfterIndex to 0 (default) means that the Watcher
+	// should start watching for events starting at the current
+	// index, whatever that may be.
+	watcher := c.client.Watcher(prefix, &client.WatcherOptions{AfterIndex: uint64(0), Recursive: true})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancelRoutine := make(chan bool)
-	respChan := make(chan watchResponse)
 	defer close(cancelRoutine)
 
 	go func() {
-		for {
-			select {
-			case <-cancelRoutine:
-				cancel()
-				return
-			default:
-				// Setting AfterIndex to 0 (default) means that the Watcher
-				// should start watching for events starting at the current
-				// index, whatever that may be.
-				watcher := c.client.Watcher(prefix, &client.WatcherOptions{AfterIndex: uint64(0), Recursive: true})
-				resp, err := watcher.Next(ctx)
-				if err != nil {
-					switch e := err.(type) {
-					case *client.Error:
-						if e.Code == 401 {
-							respChan <- watchResponse{0, nil}
-							return
-						}
-					}
-					respChan <- watchResponse{waitIndex, err}
-					return
-				}
-
-				// Only return if we have a key prefix we care about.
-				// This is not an exact match on the key so there is a chance
-				// we will still pickup on false positives. The net win here
-				// is reducing the scope of keys that can trigger updates.
-				for _, k := range keys {
-					if strings.HasPrefix(resp.Node.Key, k) {
-						respChan <- watchResponse{resp.Node.ModifiedIndex, err}
-						return
-					}
-				}
-			}
-		}
-	}()
-	for {
 		select {
 		case <-stopChan:
-			return waitIndex, nil
-		case r := <-respChan:
-			return r.waitIndex, r.err
+			cancel()
+		case <-cancelRoutine:
+			return
+		}
+	}()
+
+	for {
+		resp, err := watcher.Next(ctx)
+		if err != nil {
+			switch e := err.(type) {
+			case *client.Error:
+				if e.Code == 401 {
+					return 0, nil
+				}
+			}
+			return waitIndex, err
+		}
+
+		// Only return if we have a key prefix we care about.
+		// This is not an exact match on the key so there is a chance
+		// we will still pickup on false positives. The net win here
+		// is reducing the scope of keys that can trigger updates.
+		for _, k := range keys {
+			if strings.HasPrefix(resp.Node.Key, k) {
+				return resp.Node.ModifiedIndex, err
+			}
 		}
 	}
 }


### PR DESCRIPTION
I think it is not necessary to run 

```
ctx, cancel := context.WithCancel(context.Background())
cancelRoutine := make(chan bool)
defer close(cancelRoutine)

go func() {
    select {
    case <-stopChan:
        cancel()
    case <-cancelRoutine:
        return
    }
}()
```

all the time in the for loop. 
This will waste resources in the case that keys with a key prefix we don't care about are changed in a high frequency.

I made a few simple changes to the watchPrefix method to improve these behavior.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kelseyhightower/confd/403)

<!-- Reviewable:end -->
