### PR TITLE
extended getenv & map template functions

### DIFF
--- a/resource/template/template_funcs.go
+++ b/resource/template/template_funcs.go
@@ -20,7 +20,7 @@ func newFuncMap() map[string]interface{} {
 	m["jsonArray"] = UnmarshalJsonArray
 	m["dir"] = path.Dir
 	m["map"] = CreateMap
-	m["getenv"] = os.Getenv
+	m["getenv"] = Getenv
 	m["join"] = strings.Join
 	m["datetime"] = time.Now
 	m["toUpper"] = strings.ToUpper
@@ -36,6 +36,22 @@ func addFuncs(out, in map[string]interface{}) {
 	for name, fn := range in {
 		out[name] = fn
 	}
+}
+
+// Getenv retrieves the value of the environment variable named by the key.
+// It returns the value, which will the default value if the variable is not present.
+// If no default value was given - returns "".
+func Getenv(key string, v ...string) string {
+	defaultValue := ""
+	if len(v) > 0 {
+		defaultValue = v[0]
+	}
+
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	return value
 }
 
 // CreateMap creates a key-value map of string -> interface{}


### PR DESCRIPTION
### getenv
extended the `getenv` template function to allow default values.
useful when you want to have a default value if nothing was supplied, for instance:
`{{ getenv "HOST_IP" "127.0.0.1" }}`

### map
added a new `map` function that allows to create maps inside a template. for instance:
`{{$endpoint := map "name" $name "private_port" $private_port "public_port" $public_port}}`

this is very useful if you have a defined sub-templates and you want to pass multiple values to them.
the idea & code was written by **tux21b** at [stackoverflow](https://stackoverflow.com/questions/18276173/calling-a-template-with-several-pipeline-parameters/18276968#18276968)
