### PR TITLE
Enabling 2nd Backend git 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+.idea

--- a/backends/etcd/client.go
+++ b/backends/etcd/client.go
@@ -138,7 +138,6 @@ func (c *Client) WatchPrefix(prefix string, keys []string, waitIndex uint64, sto
 				return
 			}
 		}()
-
 		resp, err := watcher.Next(ctx)
 		if err != nil {
 			switch e := err.(type) {

--- a/confd.go
+++ b/confd.go
@@ -30,6 +30,19 @@ func main() {
 	}
 
 	templateConfig.StoreClient = storeClient
+
+	// 2nd backend setup
+	if backendsConfig2.Backend != "" {
+		log.Debug("Preparing 2nd Backend Config ")
+		storeClient2, err2 := backends.New(backendsConfig2)
+
+		if err2 != nil {
+			log.Fatal(err2.Error())
+		} else {
+			templateConfig.StoreClient2 = storeClient2
+		}
+	}
+
 	if onetime {
 		if err := template.Process(templateConfig); err != nil {
 			log.Fatal(err.Error())

--- a/docs/command-line-flags.md
+++ b/docs/command-line-flags.md
@@ -10,20 +10,36 @@ confd -h
 Usage of confd:
   -app-id string
       Vault app-id to use with the app-id backend (only used with -backend=vault and auth-type=app-id)
+  -app-id2 string
+      Vault app-id to use with the app-id optional 2nd backend (only used with -backend2=vault and auth-type2=app-id)
   -auth-token string
       Auth bearer token to use
+  -auth-token2 string
+      Auth bearer token to use for the 2nd backend
   -auth-type string
       Vault auth backend type to use (only used with -backend=vault)
+  -auth-type2 string
+      Vault auth 2nd backend type to use (only used with -backend2=vault)
   -backend string
       backend to use (default "etcd")
+  -backend2 string
+      2nd backend to use (default "etcd")
   -basic-auth
       Use Basic Auth to authenticate (only used with -backend=etcd)
+  -basic-auth2
+      Use Basic Auth to authenticate with 2nd backend (only used with -backend2=etcd)
   -client-ca-keys string
       client ca keys
+  -client-ca-keys2 string
+      client ca keys for the 2nd backend
   -client-cert string
       the client cert
+  -client-cert2 string
+      the client cert for the 2nd backend
   -client-key string
       the client key
+  -client-key2 string
+      the client key for the 2nd backend
   -confdir string
       confd conf directory (default "/etc/confd")
   -config-file string
@@ -36,14 +52,20 @@ Usage of confd:
       level which confd should log messages
   -node value
       list of backend nodes (default [])
+  -node2 value
+      list of 2nd backend nodes (default [])
   -noop
       only show pending changes
   -onetime
       run once and exit
   -password string
       the password to authenticate with (only used with vault and etcd backends)
+  -password2 string
+      the password to authenticate with (only used with vault and etcd 2nd backends) to use for 2nd backend
   -prefix string
       key path prefix (default "/")
+  -prefix2 string
+      key path prefix for the 2nd backend (default "/")
   -scheme string
       the backend URI scheme for nodes retrieved from DNS SRV records (http or https) (default "http")
   -srv-domain string
@@ -54,10 +76,16 @@ Usage of confd:
       sync without check_cmd and reload_cmd
   -table string
       the name of the DynamoDB table (only used with -backend=dynamodb)
+  -table2 string
+      the name of the DynamoDB table (only used with -backend2=dynamodb) to use for 2nd backend
   -user-id string
       Vault user-id to use with the app-id backend (only used with -backend=value and auth-type=app-id)
+  -user-id2 string
+      Vault app-id2 to use with the app-id2 on 2nd backend (only used with -backend2=vault and auth-type2=app-id)
   -username string
       the username to authenticate as (only used with vault and etcd backends)
+  -username2 string
+      the username to authenticate as (only used with vault and etcd 2nd backends ) to use for 2nd backend
   -version
       print version and exit
   -watch

--- a/docs/multiple-backends.md
+++ b/docs/multiple-backends.md
@@ -1,0 +1,59 @@
+# Multiple Backends
+
+Currently confd allows you to monitor up to two backends at the same time. Both backend's collected data can be used within the same tamplate.
+
+## How to configure 2nd backend
+
+To enable the use of the 2nd backend you need to set the flag `-backend2=` to the type of the backend that you are using. 
+Any other settings that backend2 might require ( depending on the backend you use) will have appended '2' to the end of the flag.
+
+All of the available 2nd backend flags that can be set are :
+
+- "auth-token2:
+- "auth-type2":
+- "backend2":
+- "basic-auth2":
+- "client-cert2":
+- "client-key2":
+- "client-ca-keys2":
+- "node2":
+- "password2":
+- "prefix2":
+- "table2":
+- "username2":
+- "app-id2":
+- "user-id2":
+
+
+## How to user 2nd backend vars in the template
+
+All of the data from the 2nd backend are available along side the ones from the 1st backend. 
+Keys from the 2nd backend are prefixed with ```backend2:``` while keys from the 1st backend for backwards compatibility can be accessed without the prefix.
+To keep things consistant keys from the 1st backend can also be accessed with ```backend1:``` prefix. 
+
+
+
+Example: *test.toml*
+
+```
+[template]
+src = "test.tmpl"
+dest = "/tmp/test.conf"
+mode = "777"
+keys = [
+  "/message",
+]
+keys2 = [
+  "/message",
+]
+```
+
+Example: *test.conf*
+
+```
+Hello here are the backend vars
+
+backend 1: value: {{getv "/message"}}
+backend 1: value: {{getv "backend1:/message"}}
+backend 2: value: {{getv "backend2:/message"}}
+```

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version = "0.12.0-dev"
+const Version = "0.13.0-dev"


### PR DESCRIPTION
This pull request allows for having confd poll two backends at the same time and provide the data from both in the same templates.

To use it : 
set `-backend2=` to backend of your choice
example:
```
confd -backend=etcd -backend2=vault -auth-type2=token -auth-token2=${AUTH_TOKE} -node2=http://10.22.1.102:8200
```
set any additional flags related to the backend2  (flags which end with '2' example `-node2=` )

set backend2 keys in the toml file, by setting `keys2=`
example:
```
[template]
src = "test.tmpl"
dest = "/tmp/test.conf"
mode = "777"
keys = [
  "/message",
]
keys2 = [
  "/secret/api/external/docker_hub",
]
```

use the backend 2 vars in the template file by prefixing the keys with `backend2:`
example: 
```
{{getv "backend2:/secret/api/external/docker_hub/username"}}
```

This request was stemmed from issue : https://github.com/kelseyhightower/confd/issues/414