### PR TITLE
Specify default Vault backend node

### DIFF
--- a/config.go
+++ b/config.go
@@ -178,6 +178,8 @@ func initConfig() error {
 			}
 		case "redis":
 			config.BackendNodes = []string{"127.0.0.1:6379"}
+		case "vault":
+			config.BackendNodes = []string{"http://127.0.0.1:8200"}
 		case "zookeeper":
 			config.BackendNodes = []string{"127.0.0.1:2181"}
 		}


### PR DESCRIPTION
Without passing `-node`, Vault will panic:

```
panic: runtime error: index out of range

goroutine 1 [running]:
panic(0xb9ece0, 0xc820010040)
	/usr/local/go/src/runtime/panic.go:464 +0x3e6
github.com/kelseyhightower/confd/backends.New(0x0, 0x0, 0x0, 0x0, 0x7fff1a2aee58, 0x5, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/kelseyhightower/go/src/github.com/kelseyhightower/confd/backends/client.go:61 +0xbdf
main.main()
	/Users/kelseyhightower/go/src/github.com/kelseyhightower/confd/confd.go:27 +0x1f4
```