### PR TITLE
add go version and git commit sha1 to version string

### DIFF
--- a/build
+++ b/build
@@ -2,4 +2,10 @@
 
 echo "Building confd..."
 mkdir -p bin
-go build -o bin/confd .
+
+GIT_COMMIT=$(git rev-parse --short HEAD)
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+  GIT_COMMIT=${GIT_COMMIT}-dirty
+fi
+
+go build -ldflags "-X main.GitCommit=$GIT_COMMIT" -o bin/confd .

--- a/confd.go
+++ b/confd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 
 	"github.com/kelseyhightower/confd/backends"
@@ -15,7 +16,7 @@ import (
 func main() {
 	flag.Parse()
 	if printVersion {
-		fmt.Printf("confd %s\n", Version)
+		fmt.Printf("confd %s (Git commit: %s, Go version: %s)\n", Version, GitCommit, runtime.Version())
 		os.Exit(0)
 	}
 	if err := initConfig(); err != nil {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,6 @@
 package main
 
 const Version = "0.12.0-dev"
+
+// We want to replace this variable at build time with "-ldflags -X main.GitCommit=xxx", where const is not supported.
+var GitCommit = ""


### PR DESCRIPTION
New features may be added to golang template.
If the user want to use the new feature (for example, go 1.6 supports trimming whitespace characters), they have to check the go version that the binary was built with. So I think adding the golang version to the `-version` command's output may be useful.

Signed-off-by: Shijiang Wei mountkin@gmail.com
