### PR TITLE
Support metad backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ before_install:
   - mkdir /tmp/zookeeper && cp integration/zookeeper/zoo.cfg zookeeper-3.4.8/conf/zoo.cfg
   - zookeeper-3.4.8/bin/zkServer.sh start
   # Install metad
-  - wget https://github.com/yunify/metad/releases/download/v1.0-alpha.5/metad-linux-amd64
-  - sudo mv metad-linux-amd64 /bin/metad
-  - sudo chmod +x /bin/metad
+  - wget https://github.com/yunify/metad/releases/download/v1.0-alpha.6/metad-linux-amd64.tar.gz
+  - tar -zxvf metad-linux-amd64.tar.gz
+  - sudo mv metad /bin/
 install:
   - sudo pip install awscli
   - go get golang.org/x/tools/cmd/cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install:
   # Install metad
   - wget https://github.com/yunify/metad/releases/download/v1.0-alpha.5/metad-linux-amd64
   - sudo mv metad-linux-amd64 /bin/metad
+  - sudo chomd +x /bin/metad
 install:
   - sudo pip install awscli
   - go get golang.org/x/tools/cmd/cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
   # Install metad
   - wget https://github.com/yunify/metad/releases/download/v1.0-alpha.5/metad-linux-amd64
   - sudo mv metad-linux-amd64 /bin/metad
-  - sudo chomd +x /bin/metad
+  - sudo chmod +x /bin/metad
 install:
   - sudo pip install awscli
   - go get golang.org/x/tools/cmd/cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ before_install:
   - tar xzf zookeeper-3.4.8.tar.gz
   - mkdir /tmp/zookeeper && cp integration/zookeeper/zoo.cfg zookeeper-3.4.8/conf/zoo.cfg
   - zookeeper-3.4.8/bin/zkServer.sh start
+  # Install metad
+  - wget https://github.com/yunify/metad/releases/download/v1.0-alpha.3/metad-linux-amd64
+  - sudo mv metad-linux-amd64 /bin/
 install:
   - sudo pip install awscli
   - go get golang.org/x/tools/cmd/cover
@@ -51,3 +54,4 @@ script:
   - bash integration/vault/test.sh
   - bash integration/zookeeper/test.sh
   - bash integration/dynamodb/test.sh
+  - bash integration/metad/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ before_install:
   - mkdir /tmp/zookeeper && cp integration/zookeeper/zoo.cfg zookeeper-3.4.8/conf/zoo.cfg
   - zookeeper-3.4.8/bin/zkServer.sh start
   # Install metad
-  - wget https://github.com/yunify/metad/releases/download/v1.0-alpha.3/metad-linux-amd64
-  - sudo mv metad-linux-amd64 /bin/
+  - wget https://github.com/yunify/metad/releases/download/v1.0-alpha.5/metad-linux-amd64
+  - sudo mv metad-linux-amd64 /bin/metad
 install:
   - sudo pip install awscli
   - go get golang.org/x/tools/cmd/cover

--- a/backends/client.go
+++ b/backends/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kelseyhightower/confd/backends/dynamodb"
 	"github.com/kelseyhightower/confd/backends/env"
 	"github.com/kelseyhightower/confd/backends/etcd"
+	"github.com/kelseyhightower/confd/backends/metad"
 	"github.com/kelseyhightower/confd/backends/rancher"
 	"github.com/kelseyhightower/confd/backends/redis"
 	"github.com/kelseyhightower/confd/backends/stackengine"
@@ -65,6 +66,8 @@ func New(config Config) (StoreClient, error) {
 		return dynamodb.NewDynamoDBClient(table)
 	case "stackengine":
 		return stackengine.NewStackEngineClient(backendNodes, config.Scheme, config.ClientCert, config.ClientKey, config.ClientCaKeys, config.AuthToken)
+	case "metad":
+		return metad.NewMetadClient(backendNodes[0])
 	}
 	return nil, errors.New("Invalid backend")
 }

--- a/backends/metad/client.go
+++ b/backends/metad/client.go
@@ -139,10 +139,11 @@ func (c *Client) WatchPrefix(prefix string, keys []string, waitIndex uint64, sto
 	}()
 
 	// just ignore resp, notify confd to reload metadata from metad
-	_, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return c.waitIndex, err
 	}
+	resp.Body.Close()
 	c.waitIndex = c.waitIndex + 1
 	return c.waitIndex, nil
 

--- a/backends/metad/client.go
+++ b/backends/metad/client.go
@@ -123,6 +123,8 @@ func (c *Client) WatchPrefix(prefix string, keys []string, waitIndex uint64, sto
 		c.waitIndex = 1
 		return c.waitIndex, nil
 	}
+	done := make(chan struct{})
+	defer close(done)
 
 	req, _ := http.NewRequest("GET", fmt.Sprintf("%s%s?wait=true", c.url, prefix), nil)
 	req.Header.Set("Accept", "application/json")
@@ -131,6 +133,8 @@ func (c *Client) WatchPrefix(prefix string, keys []string, waitIndex uint64, sto
 		select {
 		case <-stopChan:
 			c.transport.CancelRequest(req)
+		case <-done:
+			return
 		}
 	}()
 

--- a/backends/metad/client.go
+++ b/backends/metad/client.go
@@ -140,10 +140,10 @@ func (c *Client) WatchPrefix(prefix string, keys []string, waitIndex uint64, sto
 
 	// just ignore resp, notify confd to reload metadata from metad
 	resp, err := c.httpClient.Do(req)
+	defer resp.Body.Close()
 	if err != nil {
 		return c.waitIndex, err
 	}
-	resp.Body.Close()
 	c.waitIndex = c.waitIndex + 1
 	return c.waitIndex, nil
 

--- a/backends/metad/client.go
+++ b/backends/metad/client.go
@@ -1,0 +1,145 @@
+package metad
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"fmt"
+	"github.com/kelseyhightower/confd/log"
+)
+
+type Client struct {
+	url        string
+	transport  *http.Transport
+	httpClient *http.Client
+	waitIndex  uint64
+}
+
+func NewMetadClient(backendNode string) (*Client, error) {
+	url := "http://" + backendNode
+
+	log.Info("Using Metad URL: " + url)
+	transport := &http.Transport{}
+	client := &Client{
+		url: url,
+		httpClient: &http.Client{
+			Transport: transport,
+		},
+		transport: transport,
+	}
+
+	err := client.testConnection()
+	return client, err
+
+}
+
+func (c *Client) GetValues(keys []string) (map[string]string, error) {
+	vars := map[string]string{}
+
+	for _, key := range keys {
+		body, err := c.makeMetaDataRequest(key)
+		if err != nil {
+			return vars, err
+		}
+
+		var jsonResponse interface{}
+		if err = json.Unmarshal(body, &jsonResponse); err != nil {
+			return vars, err
+		}
+
+		if err = treeWalk(key, jsonResponse, vars); err != nil {
+			return vars, err
+		}
+	}
+	return vars, nil
+}
+
+func treeWalk(root string, val interface{}, vars map[string]string) error {
+	switch val.(type) {
+	case map[string]interface{}:
+		for k := range val.(map[string]interface{}) {
+			treeWalk(strings.Join([]string{root, k}, "/"), val.(map[string]interface{})[k], vars)
+		}
+	case []interface{}:
+		for i, item := range val.([]interface{}) {
+			idx := strconv.Itoa(i)
+			if i, isMap := item.(map[string]interface{}); isMap {
+				if name, exists := i["name"]; exists {
+					idx = name.(string)
+				}
+			}
+
+			treeWalk(strings.Join([]string{root, idx}, "/"), item, vars)
+		}
+	case bool:
+		vars[root] = strconv.FormatBool(val.(bool))
+	case string:
+		vars[root] = val.(string)
+	case float64:
+		vars[root] = strconv.FormatFloat(val.(float64), 'f', -1, 64)
+	case nil:
+		vars[root] = "null"
+	default:
+		log.Error("Unknown type: " + reflect.TypeOf(val).Name())
+	}
+	return nil
+}
+
+func (c *Client) makeMetaDataRequest(path string) ([]byte, error) {
+	req, _ := http.NewRequest("GET", strings.Join([]string{c.url, path}, ""), nil)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return ioutil.ReadAll(resp.Body)
+}
+
+func (c *Client) testConnection() error {
+	var err error
+	maxTime := 20 * time.Second
+
+	for i := 1 * time.Second; i < maxTime; i *= time.Duration(2) {
+		if _, err = c.makeMetaDataRequest("/"); err != nil {
+			time.Sleep(i)
+		} else {
+			return nil
+		}
+	}
+	return err
+}
+
+func (c *Client) WatchPrefix(prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {
+	// return something > 0 to trigger a key retrieval from the store
+	if waitIndex == 0 {
+		c.waitIndex = 1
+		return c.waitIndex, nil
+	}
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("%s%s?wait=true", c.url, prefix), nil)
+	req.Header.Set("Accept", "application/json")
+
+	go func() {
+		select {
+		case <-stopChan:
+			c.transport.CancelRequest(req)
+		}
+	}()
+
+	// just ignore resp, notify confd to reload metadata from metad
+	_, err := c.httpClient.Do(req)
+	if err != nil {
+		return c.waitIndex, err
+	}
+	c.waitIndex = c.waitIndex + 1
+	return c.waitIndex, nil
+
+}

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -15,6 +15,7 @@ confd supports the following backends:
 * dynamodb
 * stackengine
 * rancher
+* metad
 
 ### Add keys
 
@@ -91,6 +92,11 @@ curl -k -X PUT -d 'value' https://mesh-01:8443/api/kv/key --header "Authorizatio
 #### Rancher
 
 This backend consumes the [Rancher](https://www.rancher.com) metadata service. For available keys, see the [Rancher Metadata Service docs](http://docs.rancher.com/rancher/rancher-services/metadata-service/).
+
+#### Metad
+```
+curl http://127.0.0.1:9611/v1/data -X PUT -d '{"myapp":{"database":{"url":"db.example.com","user":"rob"}}}'
+```
 
 ### Create the confdir
 
@@ -174,12 +180,18 @@ confd -onetime -backend stackengine -auth-token stackengine_api_key -node 192.16
 confd -onetime -backend redis -node 192.168.255.210:6379
 ```
 
-=======
 #### rancher
 
 ```
 confd -onetime -backend rancher -prefix /2015-07-25
 ```
+
+#### metad
+
+```
+confd --onetime --backend metad --node 127.0.0.1:80 --watch
+```
+=======
 
 *Note*: The metadata api prefix can be defined on the cli, or as part of your keys in the template toml file.
 

--- a/integration/metad/test.sh
+++ b/integration/metad/test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+metad --backend local --log_level info --listen :9090 --listen_manage 127.0.0.1:9611 --xff &
+
+sleep 1
+
+curl -X PUT http://127.0.0.1:9611/v1/data -d '{
+        "key": "foobar",
+        "database": {
+           "host": "127.0.0.1",
+           "password": "p@sSw0rd",
+           "port": 3306,
+           "username": "confd"
+         },
+         "upstream": {
+           "app1": "10.0.1.10:8080",
+           "app2": "10.0.1.11:8080"
+         },
+         "prefix": {
+           "database": {
+              "host": "127.0.0.1",
+              "password": "p@sSw0rd",
+              "port": 3306,
+              "username": "confd"
+            },
+            "upstream": {
+              "app1": "10.0.1.10:8080",
+              "app2": "10.0.1.11:8080"
+            }
+         }
+}'
+
+sleep 1
+
+confd --onetime --log-level debug --confdir ./integration/confdir --backend metad --node 127.0.0.1:9090 --watch


### PR DESCRIPTION
Add metad backend to confd.
[Metad](https://github.com/yunify/metad) is a metadata server tool, support self semantic. metad keep a mapping of IP and metadata, client direct request "/self", will get the metadata of current node.
