### PR TITLE
Upgrade Dockerfile to use latest stable Alpine which has Go 1.6

### DIFF
--- a/Dockerfile.build.alpine
+++ b/Dockerfile.build.alpine
@@ -1,7 +1,6 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 ENV GOPATH /go
-ENV GO15VENDOREXPERIMENT 1
 
 RUN mkdir -p "$GOPATH/src/" "$GOPATH/bin" && chmod -R 777 "$GOPATH" && \
     mkdir -p /go/src/github.com/kelseyhightower/confd


### PR DESCRIPTION
Hi everyone,

I wanted to use the "suppress newlines" feature introduced in Go 1.6 with confd. Turned out, the release binaries uploaded to Github are made with Go 1.5.
The latest, stable(!) Alpine version already ships with Go 1.6, so I thought we should upgrade the builder Dockerfile to use it.

The mentioned feature:

> {{end}} vs. {{- end}} and {{end -}} will suppress unnecessary empty lines in the confd generated output, creating a much human-readable output file.