### PR TITLE
Adding nested key support to Vault backend

### DIFF
--- a/integration/confdir/conf.d/nested.toml
+++ b/integration/confdir/conf.d/nested.toml
@@ -1,0 +1,7 @@
+[template]
+mode = "0644"
+src = "nested.conf.tmpl"
+dest = "/tmp/confd-nested-test.conf"
+keys = [
+  "/nested",
+]

--- a/integration/confdir/templates/nested.conf.tmpl
+++ b/integration/confdir/templates/nested.conf.tmpl
@@ -1,0 +1,18 @@
+upstream app {
+{{range gets "/nested/*"}}  
+  {{range gets .Key}}  
+    server {{.Value}};
+  {{end}}
+{{end}}
+}
+
+server {
+    server_name  www.example.com;
+    location / {
+        proxy_pass        http://app;
+        proxy_redirect    off;
+        proxy_set_header  Host             $host;
+        proxy_set_header  X-Real-IP        $remote_addr;
+        proxy_set_header  X-Forwarded-For  $proxy_add_x_forwarded_for;
+   }
+}

--- a/integration/vault/test.sh
+++ b/integration/vault/test.sh
@@ -12,7 +12,8 @@ vault write database/port value=3306
 vault write database/username value=confd
 vault write database/password value=p@sSw0rd
 vault write upstream app1=10.0.1.10:8080 app2=10.0.1.11:8080
-
+vault write nested/east/app1 value=10.0.1.10:8080
+vault write nested/west/app2 value=10.0.1.11:8080
 
 # Run confd
 confd --onetime --log-level debug \


### PR DESCRIPTION
This will recursively list keys in the vault backend so the conf.d/*.toml only needs to list the parent key. This still needs testing. I've included some untested updates to the vault integration tests, need more integration tests for the other backends, and I've made no changes to the unit tests.
