### PR TITLE
override auto-resolved dynamodb endpoint

### DIFF
--- a/backends/client.go
+++ b/backends/client.go
@@ -60,9 +60,9 @@ func New(config Config) (StoreClient, error) {
 		}
 		return vault.New(backendNodes[0], config.AuthType, vaultConfig)
 	case "dynamodb":
-		table := config.Table
-		log.Info("DynamoDB table set to " + table)
-		return dynamodb.NewDynamoDBClient(table)
+		log.Info("DynamoDB table set to " + config.Table)
+		log.Info("DynamoDB endpoint set to " + config.Endpoint)
+		return dynamodb.NewDynamoDBClient(config.Table, config.Endpoint)
 	case "stackengine":
 		return stackengine.NewStackEngineClient(backendNodes, config.Scheme, config.ClientCert, config.ClientKey, config.ClientCaKeys, config.AuthToken)
 	}

--- a/backends/config.go
+++ b/backends/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	Password     string
 	Scheme       string
 	Table        string
+	Endpoint     string
 	Username     string
 	AppID        string
 	UserID       string

--- a/backends/dynamodb/client.go
+++ b/backends/dynamodb/client.go
@@ -1,8 +1,6 @@
 package dynamodb
 
 import (
-	"os"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -18,12 +16,12 @@ type Client struct {
 
 // NewDynamoDBClient returns an *dynamodb.Client with a connection to the region
 // configured via the AWS_REGION environment variable.
+// if endpoint is not equal to an emtpy string it overrides the aws config endpoint
 // It returns an error if the connection cannot be made or the table does not exist.
-func NewDynamoDBClient(table string) (*Client, error) {
+func NewDynamoDBClient(table, endpoint string) (*Client, error) {
 	var c *aws.Config
-	if os.Getenv("DYNAMODB_LOCAL") != "" {
-		log.Debug("DYNAMODB_LOCAL is set")
-		endpoint := "http://localhost:8000"
+	if endpoint != "" {
+		log.Debug("local development endpoint is set")
 		c = &aws.Config{
 			Endpoint: &endpoint,
 		}

--- a/config.go
+++ b/config.go
@@ -42,6 +42,7 @@ var (
 	srvRecord         string
 	syncOnly          bool
 	table             string
+	endpoint          string
 	templateConfig    template.Config
 	backendsConfig    backends.Config
 	username          string
@@ -71,6 +72,7 @@ type Config struct {
 	Scheme       string   `toml:"scheme"`
 	SyncOnly     bool     `toml:"sync-only"`
 	Table        string   `toml:"table"`
+	Endpoint     string   `toml:"endpoint"`
 	Username     string   `toml:"username"`
 	LogLevel     string   `toml:"log-level"`
 	Watch        bool     `toml:"watch"`
@@ -103,6 +105,7 @@ func init() {
 	flag.StringVar(&appID, "app-id", "", "Vault app-id to use with the app-id backend (only used with -backend=vault and auth-type=app-id)")
 	flag.StringVar(&userID, "user-id", "", "Vault user-id to use with the app-id backend (only used with -backend=value and auth-type=app-id)")
 	flag.StringVar(&table, "table", "", "the name of the DynamoDB table (only used with -backend=dynamodb)")
+	flag.StringVar(&endpoint, "endpoint", "", "override auto-resolved DynamoDB endpoint (E.g. http://localhost:8000) (only used with -backend=dynamodb)")
 	flag.StringVar(&username, "username", "", "the username to authenticate as (only used with vault and etcd backends)")
 	flag.StringVar(&password, "password", "", "the password to authenticate with (only used with vault and etcd backends)")
 	flag.BoolVar(&watch, "watch", false, "enable watch support")
@@ -216,6 +219,7 @@ func initConfig() error {
 		Password:     config.Password,
 		Scheme:       config.Scheme,
 		Table:        config.Table,
+		Endpoint:     config.Endpoint,
 		Username:     config.Username,
 		AppID:        config.AppID,
 		UserID:       config.UserID,
@@ -310,6 +314,8 @@ func setConfigFromFlag(f *flag.Flag) {
 		config.SyncOnly = syncOnly
 	case "table":
 		config.Table = table
+	case "endpoint":
+		config.Endpoint = endpoint
 	case "username":
 		config.Username = username
 	case "log-level":


### PR DESCRIPTION
# Set endpoint with cli parameter

## What is the problem/feature?

Setting the environment attribute`DYNAMODB_LOCAL=true` statically sets the DynamoDB URL to `http://localhost:8000`. 

However, when running confd in container and trying to `docker run --link dynamodb...` to a containerized DynamoDB instance it failes to connect as it does not allow the alternate URL (E.g. http://dynamodb:8000) of the container's hostname.

```bash
2017-02-16T16:31:21Z b22901cf46b1 /usr/local/confd/bin/confd[1]: FATAL RequestError: send request failed
caused by: Post http://localhost:8000/: dial tcp 127.0.0.1:8000: getsockopt: connection refused
```

This is the expected behavior since the container is not listening on `127.0.0.1:8000`

## How did it get fixed/implemented?

- Added the cli flag `-endpoint` that defaults to `''` to preserve existing auto-resolved endpoint.
- If `-endpoint` is set to a value like `http://localhost:8000` or `http://dynamodb:8000` it will override the `backendConfig.Endpoint` and set `aws.Config.Endpoint`
- Removed `DYNAMODB_LOCAL` environment logic

## How can someone test/see it?

### Testing Changes
- `git clone git@github.com:johnt337/confd $GOPATH/src/github.com/kelseyhightower/confd`

- `cd $GOPATH/src/github.com/kelseyhightower/confd`

- switch to the branch or commit
    - `git checkout -b feature/dynamodb-endpoint-via-cli origin/feature/dynamodb-endpoint-via-cli`
    - (or)`git reset --hard 43abc77e1734f455cbc7bb9c5ad6a32afee1bb71`

- `./build`

### Expected Results (building & running with `--help`)
![image](https://cloud.githubusercontent.com/assets/1334469/23041841/add3cba0-f453-11e6-939a-574eca705cdb.png)

### Populate your local DynamoDB instance
![image](https://cloud.githubusercontent.com/assets/1334469/23042482/1f385ade-f456-11e6-8673-679e053c1cfc.png)

### Expected Results (running)
![image](https://cloud.githubusercontent.com/assets/1334469/23042359/aaaf7fda-f455-11e6-9160-fd371d7ee76f.png)
