### PR TITLE
feat: add option -env-sep which allow the env backend to use another char separator

### DIFF
--- a/backends/client.go
+++ b/backends/client.go
@@ -46,7 +46,7 @@ func New(config Config) (StoreClient, error) {
 	case "redis":
 		return redis.NewRedisClient(backendNodes, config.ClientKey)
 	case "env":
-		return env.NewEnvClient()
+		return env.NewEnvClient(config.EnvSep)
 	case "vault":
 		vaultConfig := map[string]string{
 			"app-id":   config.AppID,

--- a/backends/config.go
+++ b/backends/config.go
@@ -15,4 +15,5 @@ type Config struct {
 	Username     string
 	AppID        string
 	UserID       string
+	EnvSep       string
 }

--- a/backends/env/client.go
+++ b/backends/env/client.go
@@ -11,27 +11,31 @@ import (
 var replacer = strings.NewReplacer("/", "_")
 
 // Client provides a shell for the env client
-type Client struct{}
+type Client struct{
+	envSep string
+}
 
 // NewEnvClient returns a new client
-func NewEnvClient() (*Client, error) {
-	return &Client{}, nil
+func NewEnvClient(envSep string) (*Client, error) {
+	return &Client{envSep: envSep}, nil
 }
 
 // GetValues queries the environment for keys
 func (c *Client) GetValues(keys []string) (map[string]string, error) {
+	replacer := strings.NewReplacer("/", c.envSep)
 	allEnvVars := os.Environ()
 	envMap := make(map[string]string)
 	for _, e := range allEnvVars {
 		index := strings.Index(e, "=")
 		envMap[e[:index]] = e[index+1:]
 	}
+	cleanReplacer := strings.NewReplacer(c.envSep, "/")
 	vars := make(map[string]string)
 	for _, key := range keys {
-		k := transform(key)
+		k := transform(key, replacer)
 		for envKey, envValue := range envMap {
 			if strings.HasPrefix(envKey, k) {
-				vars[clean(envKey)] = envValue
+				vars[clean(envKey, cleanReplacer)] = envValue
 			}
 		}
 	}
@@ -41,16 +45,14 @@ func (c *Client) GetValues(keys []string) (map[string]string, error) {
 	return vars, nil
 }
 
-func transform(key string) string {
+func transform(key string, replacer *strings.Replacer) string {
 	k := strings.TrimPrefix(key, "/")
 	return strings.ToUpper(replacer.Replace(k))
 }
 
-var cleanReplacer = strings.NewReplacer("_", "/")
-
-func clean(key string) string {
+func clean(key string, replacer *strings.Replacer) string {
 	newKey := "/" + key
-	return cleanReplacer.Replace(strings.ToLower(newKey))
+	return replacer.Replace(strings.ToLower(newKey))
 }
 
 func (c *Client) WatchPrefix(prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {

--- a/config.go
+++ b/config.go
@@ -49,6 +49,7 @@ var (
 	watch             bool
 	appID             string
 	userID            string
+	envSep            string
 )
 
 // A Config structure is used to configure confd.
@@ -76,6 +77,7 @@ type Config struct {
 	Watch        bool     `toml:"watch"`
 	AppID        string   `toml:"app_id"`
 	UserID       string   `toml:"user_id"`
+	EnvSep       string   `toml:"env_sep"`
 }
 
 func init() {
@@ -102,6 +104,7 @@ func init() {
 	flag.StringVar(&authType, "auth-type", "", "Vault auth backend type to use (only used with -backend=vault)")
 	flag.StringVar(&appID, "app-id", "", "Vault app-id to use with the app-id backend (only used with -backend=vault and auth-type=app-id)")
 	flag.StringVar(&userID, "user-id", "", "Vault user-id to use with the app-id backend (only used with -backend=value and auth-type=app-id)")
+	flag.StringVar(&envSep, "env-sep", "_", "the char that backend 'env' will replace for slashes ('/')")
 	flag.StringVar(&table, "table", "", "the name of the DynamoDB table (only used with -backend=dynamodb)")
 	flag.StringVar(&username, "username", "", "the username to authenticate as (only used with vault and etcd backends)")
 	flag.StringVar(&password, "password", "", "the password to authenticate with (only used with vault and etcd backends)")
@@ -219,6 +222,7 @@ func initConfig() error {
 		Username:     config.Username,
 		AppID:        config.AppID,
 		UserID:       config.UserID,
+		EnvSep:       config.EnvSep,
 	}
 	// Template configuration.
 	templateConfig = template.Config{
@@ -320,5 +324,7 @@ func setConfigFromFlag(f *flag.Flag) {
 		config.AppID = appID
 	case "user-id":
 		config.UserID = userID
+	case "env-sep":
+		config.EnvSep = envSep
 	}
 }

--- a/docs/command-line-flags.md
+++ b/docs/command-line-flags.md
@@ -28,6 +28,8 @@ Usage of confd:
       confd conf directory (default "/etc/confd")
   -config-file string
       the confd config file
+  -env-sep string
+      the char that backend 'env' will replace for slashes ('/') (default "_")
   -interval int
       backend polling interval (default 600)
   -keep-stage-file


### PR DESCRIPTION
Because the kelsey fork seems dead and you seems to be the community champion, here I am.
This PR is a shameless attempt to fix the problem reported in [here](https://groups.google.com/forum/#!topic/confd-users/k56ifrMmR28). It add a new option called -env-sep which allow the env backend to use another character separator. Actually, this character is _. This is not always practical because you cannot specify _ in a key while using env backend.

Regards,
Nic