### PR TITLE
Fix typo in quick-start-guide.md

### DIFF
--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -34,7 +34,7 @@ curl -X PUT -d 'db.example.com' http://localhost:8500/v1/kv/myapp/database/url
 curl -X PUT -d 'rob' http://localhost:8500/v1/kv/myapp/database/user
 ```
 
-####vault
+#### vault
 ```
 vault mount -path myapp generic
 vault write myapp/database url=db.example.com user=rob


### PR DESCRIPTION
use right md syntax to fix `valut` title