### PR TITLE
Introducing WaitPrefix for the Rancher backend

### DIFF
--- a/config.go
+++ b/config.go
@@ -191,7 +191,6 @@ func initConfig() error {
 		unsupportedBackends := map[string]bool{
 			"redis":    true,
 			"dynamodb": true,
-			"rancher":  true,
 		}
 
 		if unsupportedBackends[config.Backend] {


### PR DESCRIPTION
Rancher recently added long polling capabilities to their metadata API.
This commit implements the previously stubbed confd WaitPrefix method.