### PR TITLE
Add elementary integer oprations and quorum.

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -242,6 +242,27 @@ val: {{.}}
 {{end}}
 ```
 
+### add/subtract/multiply/divide
+
+Elementary integer operations.
+
+```
+{{if gt (add (len $var1) (len $var2)) 2}}
+sum is greater than two
+{{end}}
+```
+
+### quorum
+
+Returns the necessary number for a quorum to be reached.  Quorum is the minimal strict majority: `n/2+1`.
+
+```
+{{$es_hosts := split (getv "/discovery/nodes/elasticsearch") "," }}
+{{$es_quorum := quorum (len $es_hosts)}}
+
+discovery.zen.minimum_master_nodes: {{$es_quorum}}
+```
+
 ### ls
 
 Returns all subkeys, []string, where path matches its argument. Returns an empty list if path is not found.

--- a/resource/template/template_funcs.go
+++ b/resource/template/template_funcs.go
@@ -30,6 +30,11 @@ func newFuncMap() map[string]interface{} {
 	m["lookupIP"] = LookupIP
 	m["lookupSRV"] = LookupSRV
 	m["fileExists"] = isFileExist
+	m["quorum"] = func(x int) int { return (x/2)+1 }
+	m["add"] = func(x, y int) int { return x + y }
+	m["subtract"] = func(x, y int) int { return x - y }
+	m["multiply"] = func(x, y int) int { return x * y }
+	m["divide"] = func(x, y int) int { return x / y }
 	return m
 }
 


### PR DESCRIPTION
We use confd for service discovery, and it is a huge pain to use a separate service to calculate n/2+1 for elasticsearch configuration.

This greatly simplifies configs without adding too much obscurity.