### PR TITLE
Env backend support for keys with underscore

### DIFF
--- a/backends/env/client.go
+++ b/backends/env/client.go
@@ -28,10 +28,12 @@ func (c *Client) GetValues(keys []string) (map[string]string, error) {
 	}
 	vars := make(map[string]string)
 	for _, key := range keys {
-		k := transform(key)
+		keyNoSlashPrefix := strings.TrimPrefix(key, "/")
+		k := transform(keyNoSlashPrefix)
 		for envKey, envValue := range envMap {
 			if strings.HasPrefix(envKey, k) {
-				vars[clean(envKey)] = envValue
+				envKeyPostfix := envKey[len(k):]
+				vars["/" + keyNoSlashPrefix + clean(envKeyPostfix)] = envValue
 			}
 		}
 	}
@@ -42,15 +44,13 @@ func (c *Client) GetValues(keys []string) (map[string]string, error) {
 }
 
 func transform(key string) string {
-	k := strings.TrimPrefix(key, "/")
-	return strings.ToUpper(replacer.Replace(k))
+	return strings.ToUpper(replacer.Replace(key))
 }
 
 var cleanReplacer = strings.NewReplacer("_", "/")
 
 func clean(key string) string {
-	newKey := "/" + key
-	return cleanReplacer.Replace(strings.ToLower(newKey))
+	return cleanReplacer.Replace(strings.ToLower(key))
 }
 
 func (c *Client) WatchPrefix(prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {

--- a/integration/confdir/conf.d/underscore_keys.toml
+++ b/integration/confdir/conf.d/underscore_keys.toml
@@ -1,0 +1,8 @@
+[template]
+mode = "0644"
+src = "underscore_keys.conf.tmpl"
+dest = "/tmp/confd-underscore_keys-test.conf"
+keys = [
+  "/with_under_scores",
+  "/path_here/with/under_scores",
+]

--- a/integration/confdir/templates/underscore_keys.conf.tmpl
+++ b/integration/confdir/templates/underscore_keys.conf.tmpl
@@ -1,0 +1,2 @@
+underscore_key: {{getv "/with_under_scores"}}
+path_underscore_key={{getv "/path_here/with/under_scores"}}

--- a/integration/consul/test.sh
+++ b/integration/consul/test.sh
@@ -7,6 +7,8 @@ curl -X PUT http://127.0.0.1:8500/v1/kv/database/port -d '3306'
 curl -X PUT http://127.0.0.1:8500/v1/kv/database/username -d 'confd'
 curl -X PUT http://127.0.0.1:8500/v1/kv/upstream/app1 -d '10.0.1.10:8080'
 curl -X PUT http://127.0.0.1:8500/v1/kv/upstream/app2 -d '10.0.1.11:8080'
+curl -X PUT http://127.0.0.1:8500/v1/kv/with_under_scores -d 'value_with_underscores'
+curl -X PUT http://127.0.0.1:8500/v1/kv/path_here/with/under_scores -d 'value_path_with_underscores'
 
 # Run confd
 confd --onetime --log-level debug --confdir ./integration/confdir --backend consul --node 127.0.0.1:8500

--- a/integration/dynamodb/test.sh
+++ b/integration/dynamodb/test.sh
@@ -57,6 +57,13 @@ aws dynamodb put-item --table-name confd --region eu-west-1 \
     --item '{ "key": { "S": "/prefix/upstream/app2" }, "value": {"S": "10.0.1.11:8080"}}' \
     --endpoint-url http://localhost:8000
 
+aws dynamodb put-item --table-name confd --region eu-west-1 \
+    --item '{ "key": { "S": "/with_under_scores" }, "value": {"S": "value_with_underscores"}}' \
+    --endpoint-url http://localhost:8000
+aws dynamodb put-item --table-name confd --region eu-west-1 \
+    --item '{ "key": { "S": "/path_here/with/under_scores" }, "value": {"S": "value_path_with_underscores"}}' \
+    --endpoint-url http://localhost:8000
+
 # Run confd, expect it to work
 confd --onetime --log-level debug --confdir ./integration/confdir --interval 5 --backend dynamodb --table confd
 if [ $? -ne 0 ]

--- a/integration/env/test.sh
+++ b/integration/env/test.sh
@@ -13,5 +13,7 @@ export PREFIX_DATABASE_PORT="3306"
 export PREFIX_DATABASE_USERNAME="confd"
 export PREFIX_UPSTREAM_APP1="10.0.1.10:8080"
 export PREFIX_UPSTREAM_APP2="10.0.1.11:8080"
+export WITH_UNDER_SCORES="value_with_underscores"
+export PATH_HERE_WITH_UNDER_SCORES="value_path_with_underscores"
 
 confd --onetime --log-level debug --confdir ./integration/confdir --interval 5 --backend env

--- a/integration/etcd/test.sh
+++ b/integration/etcd/test.sh
@@ -13,6 +13,8 @@ curl -L -X PUT http://127.0.0.1:4001/v2/keys/prefix/database/port -d value=3306
 curl -L -X PUT http://127.0.0.1:4001/v2/keys/prefix/database/username -d value=confd
 curl -L -X PUT http://127.0.0.1:4001/v2/keys/prefix/upstream/app1 -d value=10.0.1.10:8080
 curl -L -X PUT http://127.0.0.1:4001/v2/keys/prefix/upstream/app2 -d value=10.0.1.11:8080
+curl -L -X PUT http://127.0.0.1:4001/v2/keys/with_under_scores -d value=value_with_underscores
+curl -L -X PUT http://127.0.0.1:4001/v2/keys/path_here/with/under_scores -d value=value_path_with_underscores
 
 
 # Run confd

--- a/integration/rancher/test.sh
+++ b/integration/rancher/test.sh
@@ -25,7 +25,13 @@ cat > ./rancher-answers.json<<EOF
               "app1": "10.0.1.10:8080",
               "app2": "10.0.1.11:8080"
             }
-         }    
+         },
+         "with_under_scores": "value_with_underscores",
+         "path_here": {
+           "with": {
+             "under_scores": "value_path_with_underscores"
+           }
+         }
     }
 }
 EOF

--- a/integration/redis/test.sh
+++ b/integration/redis/test.sh
@@ -13,6 +13,8 @@ redis-cli set /prefix/database/port 3306
 redis-cli set /prefix/database/username confd
 redis-cli set /prefix/upstream/app1 10.0.1.10:8080
 redis-cli set /prefix/upstream/app2 10.0.1.11:8080
+redis-cli set /with_under_scores value_with_underscores
+redis-cli set /path_here/with/under_scores value_path_with_underscores
 
 # Run confd with --watch, expecting it to fail
 confd --onetime --log-level debug --confdir ./integration/confdir --interval 5 --backend redis --node 127.0.0.1:6379 --watch

--- a/integration/vault/test.sh
+++ b/integration/vault/test.sh
@@ -12,7 +12,8 @@ vault write database/port value=3306
 vault write database/username value=confd
 vault write database/password value=p@sSw0rd
 vault write upstream app1=10.0.1.10:8080 app2=10.0.1.11:8080
-
+vault write with_under_scores value=value_with_underscores
+vault write path_here/with/under_scores value=value_path_with_underscores
 
 # Run confd
 confd --onetime --log-level debug \

--- a/integration/zookeeper/test.json
+++ b/integration/zookeeper/test.json
@@ -21,5 +21,11 @@
                 "app1": "10.0.1.10:8080",
                 "app2": "10.0.1.11:8080"
                 }
-            }
+            },
+    "with_under_scores": "value_with_underscores",
+    "path_here": {
+        "with": {
+        "under_scores": "value_path_with_underscores"
+        }
+    }
 }


### PR DESCRIPTION
This patch allows underscores in paths, even when the "env" backend is used.

I attempted to add the key-value combinations for all the backend integration tests, but didn't actually run them besides for the "env" backend. The formats I saw didn't give me reason to suspect underscores aren't handled like other alphanumeric values in other backends, hope that's correct. Automated tests would have been great though.