### PR TITLE
Added instructions for Dockerfile build

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,6 +33,36 @@ $ docker run -ti --rm -v $(pwd):/app confd_builder ./build
 ```
 The above docker commands will produce binary in the local bin directory.
 
+#### Build for your Image using Multi-Stage build
+
+With multi-stage builds you can keep the whole process contained in your Dockerfile using: 
+
+```
+FROM alpine:3.6 as confd
+
+ENV GOPATH /go
+
+RUN mkdir -p "$GOPATH/src/" "$GOPATH/bin" && chmod -R 777 "$GOPATH" && \
+    mkdir -p /go/src/github.com/kelseyhightower/confd
+
+RUN apk --update add unzip curl go bash && \
+    ln -s /go/src/github.com/kelseyhightower/confd /app
+
+WORKDIR /app
+
+RUN curl -L https://github.com/kelseyhightower/confd/archive/v0.12.0-alpha3.zip --output /tmp/confd.zip && \
+    unzip -d /tmp/confd /tmp/confd.zip && \
+    cp -r /tmp/confd/*/* /app && \
+    rm -rf /tmp/confd* && \
+    ./build
+
+FROM tomcat:8.5.15-jre8-alpine
+
+COPY --from=confd /app/bin/confd /usr/local/bin/confd
+
+# Then do other useful things...
+```
+
 ### Next Steps
 
 Get up and running with the [Quick Start Guide](quick-start-guide.md).


### PR DESCRIPTION
I just wanted to add confd to my webapp container, but am unable to find an alpine apk.  So i found your instructions to do a build using a container.  In my case i would have to build just to get a binary to add to my image with a COPY.  This does it all in place using the new Multi-Stage build process.