### PR TITLE
fix unexpected auto slash and https connect fail

### DIFF
--- a/resource/template/resource.go
+++ b/resource/template/resource.go
@@ -88,10 +88,6 @@ func NewTemplateResource(path string, config Config) (*TemplateResource, error) 
 		tr.Prefix = config.Prefix
 	}
 
-	if !strings.HasPrefix(tr.Prefix, "/") {
-		tr.Prefix = "/" + tr.Prefix
-	}
-
 	if tr.Src == "" {
 		return nil, ErrEmptySrc
 	}


### PR DESCRIPTION
Two fix:
1. Now `--prefix key` will not be prepended slash auto.
2. When use https as endpoint for etcd v3, it won't connect normally. Now it can.