### PR TITLE
Add support for consul BasicAuth

### DIFF
--- a/backends/client.go
+++ b/backends/client.go
@@ -42,7 +42,11 @@ func New(config Config) (StoreClient, error) {
 	case "consul":
 		return consul.New(config.BackendNodes, config.Scheme,
 			config.ClientCert, config.ClientKey,
-			config.ClientCaKeys)
+			config.ClientCaKeys,
+			config.BasicAuth,
+			config.Username,
+			config.Password,
+		)
 	case "etcd":
 		// Create the etcd client upfront and use it for the life of the process.
 		// The etcdClient is an http.Client and designed to be reused.

--- a/backends/consul/client.go
+++ b/backends/consul/client.go
@@ -13,13 +13,20 @@ type ConsulClient struct {
 }
 
 // NewConsulClient returns a new client to Consul for the given address
-func New(nodes []string, scheme, cert, key, caCert string) (*ConsulClient, error) {
+func New(nodes []string, scheme, cert, key, caCert string, basicAuth bool, username string, password string) (*ConsulClient, error) {
 	conf := api.DefaultConfig()
 
 	conf.Scheme = scheme
 
 	if len(nodes) > 0 {
 		conf.Address = nodes[0]
+	}
+
+	if basicAuth {
+		conf.HttpAuth = &api.HttpBasicAuth{
+			Username: username,
+			Password: password,
+		}
 	}
 
 	if cert != "" && key != "" {

--- a/config.go
+++ b/config.go
@@ -85,7 +85,7 @@ type Config struct {
 func init() {
 	flag.StringVar(&authToken, "auth-token", "", "Auth bearer token to use")
 	flag.StringVar(&backend, "backend", "etcd", "backend to use")
-	flag.BoolVar(&basicAuth, "basic-auth", false, "Use Basic Auth to authenticate (only used with -backend=etcd)")
+	flag.BoolVar(&basicAuth, "basic-auth", false, "Use Basic Auth to authenticate (only used with -backend=consul and -backend=etcd)")
 	flag.StringVar(&clientCaKeys, "client-ca-keys", "", "client ca keys")
 	flag.StringVar(&clientCert, "client-cert", "", "the client cert")
 	flag.StringVar(&clientKey, "client-key", "", "the client key")

--- a/docs/command-line-flags.md
+++ b/docs/command-line-flags.md
@@ -17,7 +17,7 @@ Usage of confd:
   -backend string
       backend to use (default "etcd")
   -basic-auth
-      Use Basic Auth to authenticate (only used with -backend=etcd)
+      Use Basic Auth to authenticate (only used with -backend=consul and -backend=etcd)
   -client-ca-keys string
       client ca keys
   -client-cert string


### PR DESCRIPTION
This PR updates the consul client to support the basic authentication.
It should resolve #625.