### PR TITLE
AWS ssm - don't treat "ParameterNotFound" as a fatal error

### DIFF
--- a/backends/ssm/client.go
+++ b/backends/ssm/client.go
@@ -2,7 +2,7 @@ package ssm
 
 import (
 	"os"
-	"string"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/backends/ssm/client.go
+++ b/backends/ssm/client.go
@@ -2,6 +2,7 @@ package ssm
 
 import (
 	"os"
+	"string"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -53,7 +54,9 @@ func (c *Client) GetValues(keys []string) (map[string]string, error) {
 		if len(resp) == 0 {
 			resp, err = c.getParameter(key)
 			if err != nil {
-				return vars, err
+				if !strings.Contains(err.Error(), "ParameterNotFound") {
+					return vars, err
+				}
 			}
 		}
 		for k, v := range resp {

--- a/backends/ssm/client.go
+++ b/backends/ssm/client.go
@@ -2,7 +2,6 @@ package ssm
 
 import (
 	"os"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -53,10 +52,8 @@ func (c *Client) GetValues(keys []string) (map[string]string, error) {
 		}
 		if len(resp) == 0 {
 			resp, err = c.getParameter(key)
-			if err != nil {
-				if !strings.Contains(err.Error(), "ParameterNotFound") {
-					return vars, err
-				}
+			if err != nil && err.Error() != ssm.ErrCodeParameterNotFound {
+				return vars, err
 			}
 		}
 		for k, v := range resp {


### PR DESCRIPTION
This PR checks the SSM response error string for "ParameterNotFound" and, if found, ignores the error.  Had I been more proficient at golang, I might have checked something more substantial like a status code.   

This is in an effort to fix https://github.com/kelseyhightower/confd/issues/606.  