### PR TITLE
Add AppRole authN for Vault backend

### DIFF
--- a/backends/client.go
+++ b/backends/client.go
@@ -67,6 +67,8 @@ func New(config Config) (StoreClient, error) {
 		vaultConfig := map[string]string{
 			"app-id":   config.AppID,
 			"user-id":  config.UserID,
+			"role-id":  config.RoleID,
+			"secret-id": config.SecretID,
 			"username": config.Username,
 			"password": config.Password,
 			"token":    config.AuthToken,

--- a/backends/config.go
+++ b/backends/config.go
@@ -15,5 +15,7 @@ type Config struct {
 	Username     string
 	AppID        string
 	UserID       string
+	RoleID       string
+	SecretID     string
 	YAMLFile     string
 }

--- a/backends/vault/client.go
+++ b/backends/vault/client.go
@@ -52,6 +52,11 @@ func authenticate(c *vaultapi.Client, authType string, params map[string]string)
 	defer panicToError(&err)
 
 	switch authType {
+	case "app-role":
+		secret, err = c.Logical().Write("/auth/approle/login", map[string]interface{}{
+			"role_id": getParameter("role-id", params),
+			"secret_id": getParameter("secret-id", params),
+		})
 	case "app-id":
 		secret, err = c.Logical().Write("/auth/app-id/login", map[string]interface{}{
 			"app_id":  getParameter("app-id", params),

--- a/config.go
+++ b/config.go
@@ -50,6 +50,8 @@ var (
 	watch             bool
 	appID             string
 	userID            string
+	roleID            string
+	secretID          string
 	yamlFile          string
 )
 
@@ -79,6 +81,8 @@ type Config struct {
 	Watch         bool     `toml:"watch"`
 	AppID         string   `toml:"app_id"`
 	UserID        string   `toml:"user_id"`
+	RoleID        string   `toml:"role_id"`
+	SecretID      string   `toml:"secret_id"`
 	YAMLFile      string   `toml:"file"`
 }
 
@@ -108,6 +112,8 @@ func init() {
 	flag.StringVar(&authType, "auth-type", "", "Vault auth backend type to use (only used with -backend=vault)")
 	flag.StringVar(&appID, "app-id", "", "Vault app-id to use with the app-id backend (only used with -backend=vault and auth-type=app-id)")
 	flag.StringVar(&userID, "user-id", "", "Vault user-id to use with the app-id backend (only used with -backend=value and auth-type=app-id)")
+	flag.StringVar(&roleID, "role-id", "", "Vault role-id to use with the AppRole backend (only used with -backend=vault and auth-type=app-role)")
+	flag.StringVar(&secretID, "secret-id", "", "Vault secret-id to use with the AppRole backend (only used with -backend=vault and auth-type=app-role)")
 	flag.StringVar(&table, "table", "", "the name of the DynamoDB table (only used with -backend=dynamodb)")
 	flag.StringVar(&username, "username", "", "the username to authenticate as (only used with vault and etcd backends)")
 	flag.StringVar(&password, "password", "", "the password to authenticate with (only used with vault and etcd backends)")
@@ -239,6 +245,8 @@ func initConfig() error {
 		Username:     config.Username,
 		AppID:        config.AppID,
 		UserID:       config.UserID,
+		RoleID:       config.RoleID,
+		SecretID:     config.SecretID,
 		YAMLFile:     config.YAMLFile,
 	}
 	// Template configuration.
@@ -344,6 +352,10 @@ func setConfigFromFlag(f *flag.Flag) {
 		config.AppID = appID
 	case "user-id":
 		config.UserID = userID
+	case "role-id":
+		config.RoleID = roleID
+	case "secret-id":
+		config.SecretID = secretID
 	case "file":
 		config.YAMLFile = yamlFile
 	}

--- a/docs/command-line-flags.md
+++ b/docs/command-line-flags.md
@@ -46,8 +46,12 @@ Usage of confd:
       the password to authenticate with (only used with vault and etcd backends)
   -prefix string
       key path prefix
+  -role-id string
+      Vault role-id to use with the AppRole backend (only used with -backend=vault and auth-type=app-role)
   -scheme string
       the backend URI scheme for nodes retrieved from DNS SRV records (http or https) (default "http")
+  -secret-id string
+      Vault secret-id to use with the AppRole backend (only used with -backend=vault and auth-type=app-role)
   -secret-keyring string
       path to armored PGP secret keyring (for use with crypt functions)
   -srv-domain string


### PR DESCRIPTION
As of Vault 0.6.1, App ID is deprecated in favor of [AppRole](https://www.vaultproject.io/docs/auth/approle.html) this PR adds support for this backend authN to confd.