### PR TITLE
Vault TLS certificates auth method

### DIFF
--- a/backends/vault/client.go
+++ b/backends/vault/client.go
@@ -69,6 +69,8 @@ func authenticate(c *vaultapi.Client, authType string, params map[string]string)
 		secret, err = c.Logical().Write(fmt.Sprintf("/auth/userpass/login/%s", username), map[string]interface{}{
 			"password": password,
 		})
+	case "cert":
+		secret, err = c.Logical().Write("/auth/cert/login", map[string]interface{}{})
 	}
 
 	if err != nil {


### PR DESCRIPTION
[Vault TLS Certificates Auth Method](https://www.vaultproject.io/docs/auth/cert.html)

Authentication type `-auth-type cert`.
If `-client-cert` and `-client-key` are not set or invalid, authentication will fail.