### PR TITLE
backend/etcd: add scheme to srv discovered endpoints

### DIFF
--- a/config.go
+++ b/config.go
@@ -181,6 +181,16 @@ func initConfig() error {
 		if err != nil {
 			return errors.New("Cannot get nodes from SRV records " + err.Error())
 		}
+
+		switch config.Backend {
+		case "etcd":
+			vsm := make([]string, len(srvNodes))
+			for i, v := range srvNodes {
+				vsm[i] = config.Scheme + "://" + v
+			}
+			srvNodes = vsm
+		}
+
 		config.BackendNodes = srvNodes
 	}
 	if len(config.BackendNodes) == 0 {


### PR DESCRIPTION
I've noticed that when using SRV discovery with etcd backend the etcd client complains about unknown protocol with endpoints being just `a.b.c:2379`. Prepending the scheme to the endpoints fixes the issue.