### PR TITLE
Client insecure mode

### DIFF
--- a/backends/client.go
+++ b/backends/client.go
@@ -27,6 +27,7 @@ type StoreClient interface {
 
 // New is used to create a storage client based on our configuration.
 func New(config Config) (StoreClient, error) {
+
 	if config.Backend == "" {
 		config.Backend = "etcd"
 	}
@@ -50,7 +51,7 @@ func New(config Config) (StoreClient, error) {
 	case "etcd":
 		// Create the etcd client upfront and use it for the life of the process.
 		// The etcdClient is an http.Client and designed to be reused.
-		return etcd.NewEtcdClient(backendNodes, config.ClientCert, config.ClientKey, config.ClientCaKeys, config.BasicAuth, config.Username, config.Password)
+		return etcd.NewEtcdClient(backendNodes, config.ClientCert, config.ClientKey, config.ClientCaKeys, config.ClientInsecure, config.BasicAuth, config.Username, config.Password)
 	case "etcdv3":
 		return etcdv3.NewEtcdClient(backendNodes, config.ClientCert, config.ClientKey, config.ClientCaKeys, config.BasicAuth, config.Username, config.Password)
 	case "zookeeper":

--- a/backends/config.go
+++ b/backends/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	ClientCaKeys string     `toml:"client_cakeys"`
 	ClientCert   string     `toml:"client_cert"`
 	ClientKey    string     `toml:"client_key"`
+        ClientInsecure bool     `toml:"client_insecure"`
 	BackendNodes util.Nodes `toml:"nodes"`
 	Password     string     `toml:"password"`
 	Scheme       string     `toml:"scheme"`

--- a/backends/etcd/client.go
+++ b/backends/etcd/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
+        "github.com/kelseyhightower/confd/log"
 )
 
 // Client is a wrapper around the etcd client
@@ -19,7 +20,7 @@ type Client struct {
 }
 
 // NewEtcdClient returns an *etcd.Client with a connection to named machines.
-func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, username string, password string) (*Client, error) {
+func NewEtcdClient(machines []string, cert, key, caCert string, clientInsecure bool, basicAuth bool, username string, password string) (*Client, error) {
 	var c client.Client
 	var kapi client.KeysAPI
 	var err error
@@ -32,8 +33,13 @@ func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, 
 		TLSHandshakeTimeout: 10 * time.Second,
 	}
 
+        // Enable client insecure mode globally
+        if clientInsecure {
+                log.Warning("TLS Client config running insecure mode. Skip server CA verification.")
+        }
+
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: false,
+		InsecureSkipVerify: clientInsecure,
 	}
 
 	cfg := client.Config{

--- a/config.go
+++ b/config.go
@@ -44,6 +44,7 @@ func init() {
 	flag.StringVar(&config.ClientCaKeys, "client-ca-keys", "", "client ca keys")
 	flag.StringVar(&config.ClientCert, "client-cert", "", "the client cert")
 	flag.StringVar(&config.ClientKey, "client-key", "", "the client key")
+        flag.BoolVar(&config.ClientInsecure, "client-insecure", false, "Allow connections to SSL sites without certs")
 	flag.StringVar(&config.ConfDir, "confdir", "/etc/confd", "confd conf directory")
 	flag.StringVar(&config.ConfigFile, "config-file", "/etc/confd/confd.toml", "the confd config file")
 	flag.Var(&config.YAMLFile, "file", "the YAML file to watch for changes (only used with -backend=file)")
@@ -213,4 +214,9 @@ func processEnv() {
 	if len(key) > 0 && config.ClientKey == "" {
 		config.ClientKey = key
 	}
+
+        insecure,_ := strconv.ParseBool(os.Getenv("CONFD_CLIENT_INSECURE"))
+        if insecure && !config.ClientInsecure {
+                config.ClientInsecure = true
+        }
 }

--- a/config.go
+++ b/config.go
@@ -44,7 +44,7 @@ func init() {
 	flag.StringVar(&config.ClientCaKeys, "client-ca-keys", "", "client ca keys")
 	flag.StringVar(&config.ClientCert, "client-cert", "", "the client cert")
 	flag.StringVar(&config.ClientKey, "client-key", "", "the client key")
-        flag.BoolVar(&config.ClientInsecure, "client-insecure", false, "Allow connections to SSL sites without certs")
+        flag.BoolVar(&config.ClientInsecure, "client-insecure", false, "Allow connections to SSL sites without certs (only used with -backend=etcd)")
 	flag.StringVar(&config.ConfDir, "confdir", "/etc/confd", "confd conf directory")
 	flag.StringVar(&config.ConfigFile, "config-file", "/etc/confd/confd.toml", "the confd config file")
 	flag.Var(&config.YAMLFile, "file", "the YAML file to watch for changes (only used with -backend=file)")


### PR DESCRIPTION
Added TLS client insecure mode for etcd(v2) backend to mimic "curl --insecure". Allow connections to secured etcd without cert verification.