### PR TITLE
Fix panic on file backend change

### DIFF
--- a/backends/file/client.go
+++ b/backends/file/client.go
@@ -107,8 +107,8 @@ func nodeWalk(node interface{}, key string, vars map[string]string) error {
 
 func (c *Client) watchChanges(watcher *fsnotify.Watcher, stopChan chan bool) ResultError {
 	outputChannel := make(chan ResultError)
-	defer close(outputChannel)
 	go func() error {
+		defer close(outputChannel)
 		for {
 			select {
 			case event := <-watcher.Events:


### PR DESCRIPTION
This is a fix for the file backend.

Confd panics after a file change, when run on a file backend with the `--watch` option. The original issue is https://github.com/kelseyhightower/confd/issues/715