### PR TITLE
Make sure dir is exist before create stage file.

### DIFF
--- a/resource/template/resource.go
+++ b/resource/template/resource.go
@@ -209,8 +209,12 @@ func (t *TemplateResource) createStageFile() error {
 		return fmt.Errorf("Unable to process template %s, %s", t.Src, err)
 	}
 
+	destDir := filepath.Dir(t.Dest)
+	// make sure the dir is exist
+	os.MkdirAll(destDir, t.FileMode)
+
 	// create TempFile in Dest directory to avoid cross-filesystem issues
-	temp, err := ioutil.TempFile(filepath.Dir(t.Dest), "."+filepath.Base(t.Dest))
+	temp, err := ioutil.TempFile(destDir, "."+filepath.Base(t.Dest))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Make sure dir is exist before create stage file. This is to prevent the error that when the dir is not exist, the file will not be generated.