### PR TITLE
Refactor AWS session creation for shared config

### DIFF
--- a/backends/ssm/README.md
+++ b/backends/ssm/README.md
@@ -1,0 +1,64 @@
+# SSM Backend
+
+The SSM backend enables `confd` to pull configuration parameters from the AWS Systems Manager Parameter Store
+
+## Configuration
+
+The SSM backend utilizes the AWS SDK which utilizes the same options required by
+the AWS CLI. The backend minimally requires setting the following:
+
+-   `AWS_ACCESS_KEY_ID`
+-   `AWS_SECRET_ACCESS_KEY`
+-   `AWS_DEFAULT_REGION` and/or `AWS_REGION`
+
+### Environment Variables
+
+Environment variables can be used to provide the required configurations to
+`confd`. They will override configurations set in the config and credentials
+files.
+
+```
+export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+export AWS_DEFAULT_REGION=us-east-2
+```
+
+### Config and Credentials Files
+
+AWS credentials and configuration can be stored in the standard AWS CLI config
+files. These may be set up manually or via `aws configure`
+
+\~/.aws/credentials
+
+```
+[default]
+aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```
+
+\~/.aws/config
+
+```
+[default]
+region=us-east-2
+```
+
+### IAM Role for EC2
+
+An IAM role can be used to grant `confd` permissions to SSM. When used you will
+not need to set `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY`. When `confd` is
+executed on an EC2 instance it will acquire the AWS Region setting from EC2
+Metadata.
+
+Setup of IAM roles for EC2 instances is well documented in the AWS User Guides.
+
+
+## Options
+
+
+
+## Basic Example
+
+
+
+## Advanced Example

--- a/backends/ssm/client.go
+++ b/backends/ssm/client.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/kelseyhightower/confd/log"
@@ -17,10 +18,19 @@ type Client struct {
 
 func New() (*Client, error) {
 
+	// Attempt to get AWS Region from ec2metadata. Should determine how to
+	// shorten ec2metadata client timeout so it fails fast if not on EC2.
+	metaSession, _ := session.NewSession()
+	metaClient := ec2metadata.New(metaSession)
+	region, _ := metaClient.Region()
+
+	conf := aws.NewConfig().WithRegion(region)
+
 	// Create a session to share configuration, and load external configuration.
 	sess := session.Must(session.NewSessionWithOptions(
 		session.Options{
 			SharedConfigState: session.SharedConfigEnable,
+			Config:            *conf,
 		},
 	))
 

--- a/backends/ssm/client.go
+++ b/backends/ssm/client.go
@@ -1,6 +1,7 @@
 package ssm
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,8 +16,15 @@ type Client struct {
 }
 
 func New() (*Client, error) {
+
 	// Create a session to share configuration, and load external configuration.
-	sess := session.Must(session.NewSession())
+	sess := session.Must(session.NewSessionWithOptions(
+		session.Options{
+			SharedConfigState: session.SharedConfigEnable,
+		},
+	))
+
+	log.Debug(fmt.Sprintf("Region: %s", aws.StringValue(sess.Config.Region)))
 
 	// Fail early, if no credentials can be found
 	_, err := sess.Config.Credentials.Get()

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -15,7 +15,7 @@ confd supports the following backends:
 * zookeeper
 * dynamodb
 * rancher
-* ssm (AWS Simple Systems Manager Parameter Store)
+* [ssm](../backends/ssm/README.md) (AWS Simple Systems Manager Parameter Store)
 
 ### Add keys
 


### PR DESCRIPTION
Existing session creation was ignoring AWS config options unless the
env var `AWS_SDK_LOAD_CONFIG` was exported. The SharedConfigState option
removes that need.

Github issue #688