### PR TITLE
Update docs with caveat for symbolic links

### DIFF
--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -3,7 +3,9 @@
 The confd configuration file is written in [TOML](https://github.com/mojombo/toml)
 and loaded from `/etc/confd/confd.toml` by default. You can specify the config file via the `-config-file` command line flag.
 
-> Note: You can use confd without a configuration file. See [Command Line Flags](https://github.com/kelseyhightower/confd/blob/master/docs/command-line-flags.md).
+> Notes:
+> - You can use confd without a configuration file. See [Command Line Flags](https://github.com/kelseyhightower/confd/blob/master/docs/command-line-flags.md).
+> - The confdir cannot be a symlink due to lack of support in underlying functions. This was discussed in issue #741
 
 Optional:
 

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -108,7 +108,7 @@ aws ssm put-parameter --name "/myapp/database/user" --type "SecureString" --valu
 
 ### Create the confdir
 
-The confdir is where template resource configs and source templates are stored.
+The confdir is where template resource configs and source templates are stored. Due to underlying functions not supporting symlinks the confdirs cannot be symlinked. This was discussed in issue #741.
 
 ```
 sudo mkdir -p /etc/confd/{conf.d,templates}


### PR DESCRIPTION
confd is unable to follow symlinks due to lack of support in `filepath.Walk`. Go has decided not to address this at this time and thus we will not go to great lengths to work around that lack of
support. This was discussed further in issue #741