### PR TITLE
update readme to help people get started setting up build env

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 ## Building
 
 Go 1.10 is required to build confd, which uses the new vendor directory.
+For dependency management the dep program is needed (https://golang.github.io/dep/docs/installation.html).   
 
 ```
 $ mkdir -p $GOPATH/src/github.com/kelseyhightower


### PR DESCRIPTION
add reference to "dep" to help people not fluent in go to get started building it for themself as "dep" is not part of golang distribution itself