### PR TITLE
Check for errors returned by SSM

### DIFF
--- a/backends/ssm/client.go
+++ b/backends/ssm/client.go
@@ -72,13 +72,17 @@ func (c *Client) getParametersWithPrefix(prefix string) (map[string]string, erro
 		Recursive:      aws.Bool(true),
 		WithDecryption: aws.Bool(true),
 	}
-	c.client.GetParametersByPathPages(params,
+	err = c.client.GetParametersByPathPages(params,
 		func(page *ssm.GetParametersByPathOutput, lastPage bool) bool {
 			for _, p := range page.Parameters {
 				parameters[*p.Name] = *p.Value
 			}
 			return !lastPage
 		})
+	if err != nil {
+		return nil, err
+	}
+
 	return parameters, err
 }
 


### PR DESCRIPTION
Previously silently ignoring this error causing it to halt in the middle of pagination. In our particular case, one of the keys required access to a KMS key for decryption.