### PR TITLE
allows you to specify dynamodb endpoint.

### DIFF
--- a/backends/client.go
+++ b/backends/client.go
@@ -82,7 +82,7 @@ func New(config Config) (StoreClient, error) {
 	case "dynamodb":
 		table := config.Table
 		log.Info("DynamoDB table set to " + table)
-		return dynamodb.NewDynamoDBClient(table)
+		return dynamodb.NewDynamoDBClient(backendNodes[0], table)
 	case "ssm":
 		return ssm.New()
 	}

--- a/backends/dynamodb/client.go
+++ b/backends/dynamodb/client.go
@@ -19,13 +19,19 @@ type Client struct {
 // NewDynamoDBClient returns an *dynamodb.Client with a connection to the region
 // configured via the AWS_REGION environment variable.
 // It returns an error if the connection cannot be made or the table does not exist.
-func NewDynamoDBClient(table string) (*Client, error) {
+func NewDynamoDBClient(endpoint string, table string) (*Client, error) {
 	var c *aws.Config
+	region := os.Getenv("AWS_REGION")
 	if os.Getenv("DYNAMODB_LOCAL") != "" {
 		log.Debug("DYNAMODB_LOCAL is set")
 		endpoint := "http://localhost:8000"
 		c = &aws.Config{
 			Endpoint: &endpoint,
+		}
+	} else if endpoint != "" && region != "" {
+		c = &aws.Config{
+			Region:   aws.String(region),
+			Endpoint: aws.String(endpoint),
 		}
 	} else {
 		c = nil

--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package main
 
-const Version = "0.17.0-dev"
+const Version = "0.17.1-dev"
 
 // We want to replace this variable at build time with "-ldflags -X main.GitSHA=xxx", where const is not supported.
 var GitSHA = ""


### PR DESCRIPTION
the original code only allows to use the local dynamodb, but now, you can specify the dynamodb endpoint so that you can use the AWS's online Dynamodb services.