### PR TITLE
allow you to specify dynamodb endpoint and support the aws credentials profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - sudo mv vault /bin/
   - vault server -dev &
   # Install zookeeper
-  - wget http://www.eu.apache.org/dist/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/zookeeper-${ZOOKEEPER_VERSION}.tar.gz
+  - wget https://archive.apache.org/dist/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/zookeeper-${ZOOKEEPER_VERSION}.tar.gz
   - tar xzf zookeeper-${ZOOKEEPER_VERSION}.tar.gz
   - mkdir /tmp/zookeeper && cp integration/zookeeper/zoo.cfg zookeeper-${ZOOKEEPER_VERSION}/conf/zoo.cfg
   - zookeeper-${ZOOKEEPER_VERSION}/bin/zkServer.sh start

--- a/backends/client.go
+++ b/backends/client.go
@@ -2,7 +2,7 @@ package backends
 
 import (
 	"errors"
-	"github.com/xdhuxc/confd/backends/dynamodb"
+	"github.com/kelseyhightower/confd/backends/dynamodb"
 	"strings"
 
 	"github.com/kelseyhightower/confd/backends/consul"

--- a/backends/client.go
+++ b/backends/client.go
@@ -2,10 +2,10 @@ package backends
 
 import (
 	"errors"
+	"github.com/xdhuxc/confd/backends/dynamodb"
 	"strings"
 
 	"github.com/kelseyhightower/confd/backends/consul"
-	"github.com/kelseyhightower/confd/backends/dynamodb"
 	"github.com/kelseyhightower/confd/backends/env"
 	"github.com/kelseyhightower/confd/backends/etcd"
 	"github.com/kelseyhightower/confd/backends/etcdv3"
@@ -82,7 +82,12 @@ func New(config Config) (StoreClient, error) {
 	case "dynamodb":
 		table := config.Table
 		log.Info("DynamoDB table set to " + table)
-		return dynamodb.NewDynamoDBClient(backendNodes[0], table)
+		if len(backendNodes) >= 1 {
+			return dynamodb.NewDynamoDBClient(backendNodes[0], table, config.Profile)
+		} else {
+			return dynamodb.NewDynamoDBClient("", table, config.Profile)
+		}
+
 	case "ssm":
 		return ssm.New()
 	}

--- a/backends/client.go
+++ b/backends/client.go
@@ -82,7 +82,7 @@ func New(config Config) (StoreClient, error) {
 	case "dynamodb":
 		table := config.Table
 		log.Info("DynamoDB table set to " + table)
-		return dynamodb.NewDynamoDBClient(table)
+		return dynamodb.NewDynamoDBClient(backendNodes[0], table)
 	case "ssm":
 		return ssm.New()
 	}

--- a/backends/config.go
+++ b/backends/config.go
@@ -5,26 +5,27 @@ import (
 )
 
 type Config struct {
-	AuthToken    string     `toml:"auth_token"`
-	AuthType     string     `toml:"auth_type"`
-	Backend      string     `toml:"backend"`
-	BasicAuth    bool       `toml:"basic_auth"`
-	ClientCaKeys string     `toml:"client_cakeys"`
-	ClientCert   string     `toml:"client_cert"`
-	ClientKey    string     `toml:"client_key"`
-        ClientInsecure bool     `toml:"client_insecure"`
-	BackendNodes util.Nodes `toml:"nodes"`
-	Password     string     `toml:"password"`
-	Scheme       string     `toml:"scheme"`
-	Table        string     `toml:"table"`
-	Separator    string     `toml:"separator"`
-	Username     string     `toml:"username"`
-	AppID        string     `toml:"app_id"`
-	UserID       string     `toml:"user_id"`
-	RoleID       string     `toml:"role_id"`
-	SecretID     string     `toml:"secret_id"`
-	YAMLFile     util.Nodes `toml:"file"`
-	Filter       string     `toml:"filter"`
-	Path         string     `toml:"path"`
-	Role         string
+	AuthToken      string     `toml:"auth_token"`
+	AuthType       string     `toml:"auth_type"`
+	Backend        string     `toml:"backend"`
+	BasicAuth      bool       `toml:"basic_auth"`
+	ClientCaKeys   string     `toml:"client_cakeys"`
+	ClientCert     string     `toml:"client_cert"`
+	ClientKey      string     `toml:"client_key"`
+	ClientInsecure bool       `toml:"client_insecure"`
+	BackendNodes   util.Nodes `toml:"nodes"`
+	Password       string     `toml:"password"`
+	Scheme         string     `toml:"scheme"`
+	Table          string     `toml:"table"`
+	Separator      string     `toml:"separator"`
+	Username       string     `toml:"username"`
+	AppID          string     `toml:"app_id"`
+	UserID         string     `toml:"user_id"`
+	RoleID         string     `toml:"role_id"`
+	SecretID       string     `toml:"secret_id"`
+	YAMLFile       util.Nodes `toml:"file"`
+	Filter         string     `toml:"filter"`
+	Path           string     `toml:"path"`
+	Profile        string     `toml:"profile"`
+	Role           string
 }

--- a/backends/dynamodb/client.go
+++ b/backends/dynamodb/client.go
@@ -19,13 +19,19 @@ type Client struct {
 // NewDynamoDBClient returns an *dynamodb.Client with a connection to the region
 // configured via the AWS_REGION environment variable.
 // It returns an error if the connection cannot be made or the table does not exist.
-func NewDynamoDBClient(table string) (*Client, error) {
+func NewDynamoDBClient(endpoint string, table string) (*Client, error) {
 	var c *aws.Config
+	region := os.Getenv("AWS_REGION")
 	if os.Getenv("DYNAMODB_LOCAL") != "" {
 		log.Debug("DYNAMODB_LOCAL is set")
 		endpoint := "http://localhost:8000"
 		c = &aws.Config{
 			Endpoint: &endpoint,
+		}
+	} else if endpoint != "" && region != "" {
+		c = &aws.Config{
+			Region:   aws.String(region),
+			Endpoint: aws.String(endpoint),
 		}
 	} else {
 		c = nil

--- a/backends/dynamodb/client.go
+++ b/backends/dynamodb/client.go
@@ -1,6 +1,9 @@
 package dynamodb
 
 import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -19,36 +22,83 @@ type Client struct {
 // NewDynamoDBClient returns an *dynamodb.Client with a connection to the region
 // configured via the AWS_REGION environment variable.
 // It returns an error if the connection cannot be made or the table does not exist.
-func NewDynamoDBClient(endpoint string, table string) (*Client, error) {
+func NewDynamoDBClient(endpoint string, table string, profile string) (*Client, error) {
 	var c *aws.Config
+	var creds *credentials.Credentials
+	var sess *session.Session
 	region := os.Getenv("AWS_REGION")
-	if os.Getenv("DYNAMODB_LOCAL") != "" {
-		log.Debug("DYNAMODB_LOCAL is set")
-		endpoint := "http://localhost:8000"
-		c = &aws.Config{
-			Endpoint: &endpoint,
+	if region == "" {
+		sess, err := session.NewSession()
+		if err != nil {
+			return nil, err
 		}
-	} else if endpoint != "" && region != "" {
-		c = &aws.Config{
-			Region:   aws.String(region),
-			Endpoint: aws.String(endpoint),
+		metadata := ec2metadata.New(sess)
+		tempRegion, err := metadata.Region()
+		if err != nil {
+			return nil, fmt.Errorf("the dynamodb client requires a region")
 		}
+		region = tempRegion
+	}
+
+	if profile != "" {
+		creds = credentials.NewSharedCredentials("", profile)
+		if os.Getenv("DYNAMODB_LOCAL") != "" {
+			log.Debug("DYNAMODB_LOCAL is set")
+			endpoint := "http://localhost:8000"
+			c = &aws.Config{
+				Region:      aws.String(region),
+				Endpoint:    &endpoint,
+				Credentials: creds,
+			}
+		} else if endpoint != "" {
+			c = &aws.Config{
+				Region:      aws.String(region),
+				Endpoint:    aws.String(endpoint),
+				Credentials: creds,
+			}
+		} else {
+			c = &aws.Config{
+				Region:      aws.String(region),
+				Credentials: creds,
+			}
+		}
+		sess = session.New(c)
+		// Fail early, if no credentials can be found
+		/*
+			_, err := sess.Config.Credentials.Get()
+			if err != nil {
+				return nil, err
+			}
+		*/
 	} else {
-		c = nil
+		if os.Getenv("DYNAMODB_LOCAL") != "" {
+			log.Debug("DYNAMODB_LOCAL is set")
+			endpoint := "http://localhost:8000"
+			c = &aws.Config{
+				Endpoint: &endpoint,
+			}
+		} else if endpoint != "" {
+			c = &aws.Config{
+				Region:   aws.String(region),
+				Endpoint: aws.String(endpoint),
+			}
+		} else {
+			c = nil
+		}
+
+		sess = session.New(c)
+
+		// Fail early, if no credentials can be found
+		_, err := sess.Config.Credentials.Get()
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	session := session.New(c)
-
-	// Fail early, if no credentials can be found
-	_, err := session.Config.Credentials.Get()
-	if err != nil {
-		return nil, err
-	}
-
-	d := dynamodb.New(session)
+	d := dynamodb.New(sess)
 
 	// Check if the table exists
-	_, err = d.DescribeTable(&dynamodb.DescribeTableInput{TableName: &table})
+	_, err := d.DescribeTable(&dynamodb.DescribeTableInput{TableName: &table})
 	if err != nil {
 		return nil, err
 	}

--- a/confd.go
+++ b/confd.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kelseyhightower/confd/log"
 	"github.com/kelseyhightower/confd/resource/template"
 
-	"github.com/xdhuxc/confd/backends"
+	"github.com/kelseyhightower/confd/backends"
 )
 
 func main() {

--- a/confd.go
+++ b/confd.go
@@ -8,9 +8,10 @@ import (
 	"runtime"
 	"syscall"
 
-	"github.com/kelseyhightower/confd/backends"
 	"github.com/kelseyhightower/confd/log"
 	"github.com/kelseyhightower/confd/resource/template"
+
+	"github.com/xdhuxc/confd/backends"
 )
 
 func main() {

--- a/config.go
+++ b/config.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
-	"github.com/kelseyhightower/confd/backends"
 	"github.com/kelseyhightower/confd/log"
 	"github.com/kelseyhightower/confd/resource/template"
+	"github.com/xdhuxc/confd/backends"
 )
 
 type TemplateConfig = template.Config
@@ -44,7 +44,7 @@ func init() {
 	flag.StringVar(&config.ClientCaKeys, "client-ca-keys", "", "client ca keys")
 	flag.StringVar(&config.ClientCert, "client-cert", "", "the client cert")
 	flag.StringVar(&config.ClientKey, "client-key", "", "the client key")
-        flag.BoolVar(&config.ClientInsecure, "client-insecure", false, "Allow connections to SSL sites without certs (only used with -backend=etcd)")
+	flag.BoolVar(&config.ClientInsecure, "client-insecure", false, "Allow connections to SSL sites without certs (only used with -backend=etcd)")
 	flag.StringVar(&config.ConfDir, "confdir", "/etc/confd", "confd conf directory")
 	flag.StringVar(&config.ConfigFile, "config-file", "/etc/confd/confd.toml", "the confd config file")
 	flag.Var(&config.YAMLFile, "file", "the YAML file to watch for changes (only used with -backend=file)")
@@ -73,6 +73,7 @@ func init() {
 	flag.StringVar(&config.Username, "username", "", "the username to authenticate as (only used with vault and etcd backends)")
 	flag.StringVar(&config.Password, "password", "", "the password to authenticate with (only used with vault and etcd backends)")
 	flag.BoolVar(&config.Watch, "watch", false, "enable watch support")
+	flag.StringVar(&config.Profile, "profile", "", "the profile for the AWS's credentials, the default is empty")
 }
 
 // initConfig initializes the confd configuration by first setting defaults,

--- a/config.go
+++ b/config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kelseyhightower/confd/log"
 	"github.com/kelseyhightower/confd/resource/template"
 
-	"github.com/xdhuxc/confd/backends"
+	"github.com/kelseyhightower/confd/backends"
 )
 
 type TemplateConfig = template.Config

--- a/config.go
+++ b/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/kelseyhightower/confd/log"
 	"github.com/kelseyhightower/confd/resource/template"
+
 	"github.com/xdhuxc/confd/backends"
 )
 

--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package main
 
-const Version = "0.17.0-dev"
+const Version = "0.17.1-dev"
 
 // We want to replace this variable at build time with "-ldflags -X main.GitSHA=xxx", where const is not supported.
 var GitSHA = ""


### PR DESCRIPTION
The original code only allows to use the local dynamodb, but now, you can specify the dynamodb endpoint so that you can use the AWS's online Dynamodb services. And support the aws credentials profile, so that you can use many access keys and secret keys at the same time in a credentials file, the only thing you need to do is that specify the parameter --profile when starting confd process.