### PR TITLE
Support nil FileInfo when error, since go 1.10

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -110,6 +110,10 @@ func recursiveLookup(root string, pattern string, dirsLookup bool) ([]string, er
 	}
 	if isDir {
 		err := filepath.Walk(root, func(root string, f os.FileInfo, err error) error {
+			if err != nil {
+				log.Debug(fmt.Sprintf("Skipping error in filepath.Walk: %#v", err))
+				return nil
+			}
 			match, err := filepath.Match(pattern, f.Name())
 			if err != nil {
 				return err


### PR DESCRIPTION
Ref: https://github.com/golang/go/issues/26425

This helps if the monitored file was removed between discover and fileinfo.