### PR TITLE
Allow conf.d and templates directory to be symlinks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - sudo mv vault /bin/
   - vault server -dev &
   # Install zookeeper
-  - wget http://www.eu.apache.org/dist/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/zookeeper-${ZOOKEEPER_VERSION}.tar.gz
+  - wget https://archive.apache.org/dist/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/zookeeper-${ZOOKEEPER_VERSION}.tar.gz
   - tar xzf zookeeper-${ZOOKEEPER_VERSION}.tar.gz
   - mkdir /tmp/zookeeper && cp integration/zookeeper/zoo.cfg zookeeper-${ZOOKEEPER_VERSION}/conf/zoo.cfg
   - zookeeper-${ZOOKEEPER_VERSION}/bin/zkServer.sh start

--- a/util/util.go
+++ b/util/util.go
@@ -104,6 +104,11 @@ func RecursiveDirsLookup(root string, pattern string) ([]string, error) {
 
 func recursiveLookup(root string, pattern string, dirsLookup bool) ([]string, error) {
 	var result []string
+
+	root, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return nil, err
+	}
 	isDir, err := IsDirectory(root)
 	if err != nil {
 		return nil, err
@@ -115,6 +120,10 @@ func recursiveLookup(root string, pattern string, dirsLookup bool) ([]string, er
 				return err
 			}
 			if match {
+				root, err := filepath.EvalSymlinks(root)
+				if err != nil {
+					return err
+				}
 				isDir, err := IsDirectory(root)
 				if err != nil {
 					return err

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -5,32 +5,57 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/kelseyhightower/confd/log"
 )
 
-// createRecursiveDirs is a helper function which creates temporary directorie
-// has sub directories, and files with different extionname which will be used
-// fo function findrecursiveFindFiles's test case.The result looks like:
-// ├── root.other1
-// ├── root.toml
-// ├── subDir1
-// │   ├── sub1.other
-// │   ├── sub1.toml
-// │   └── sub12.toml
-// └── subDir2
-//       ├── sub2.other
-//       ├── sub2.toml
-//       ├── sub22.toml
-//       └── subSubDir
-//             ├── subsub.other
-//             ├── subsub.toml
-//             └── subsub2.toml
-func createDirStructure() (rootDir string, err error) {
+// createDirStructure() creates the following directory structure:
+// ├── other
+// │   ├── sym1.toml
+// │   └── sym2.toml
+// └── root
+//     ├── root.other1
+//     ├── root.toml
+//     ├── subDir1
+//     │   ├── sub1.other
+//     │   ├── sub1.toml
+//     │   └── sub12.toml
+//     ├── subDir2
+//     │   ├── sub2.other
+//     │   ├── sub2.toml
+//     │   ├── sub22.toml
+//     │   └── subSubDir
+//     │       ├── subsub.other
+//     │       ├── subsub.toml
+//     │       ├── subsub2.toml
+//     │       └── sym2.toml -> ../../../other/sym2.toml
+//     └── sym1.toml -> ../other/sym1.toml
+func createDirStructure() (string, error) {
 	mod := os.FileMode(0755)
 	flag := os.O_RDWR | os.O_CREATE | os.O_EXCL
-	rootDir, err = ioutil.TempDir("", "")
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return "", err
+	}
+
+	otherDir := filepath.Join(tmpDir, "other")
+	err = os.Mkdir(otherDir, mod)
+	if err != nil {
+		return "", err
+	}
+	_, err = os.OpenFile(otherDir+"/sym1.toml", flag, mod)
+	if err != nil {
+		return "", err
+	}
+	_, err = os.OpenFile(otherDir+"/sym2.toml", flag, mod)
+	if err != nil {
+		return "", err
+	}
+
+	rootDir := filepath.Join(tmpDir, "root")
+	err = os.Mkdir(rootDir, mod)
 	if err != nil {
 		return "", err
 	}
@@ -42,6 +67,15 @@ func createDirStructure() (rootDir string, err error) {
 	if err != nil {
 		return "", err
 	}
+	err = os.Symlink(otherDir+"/sym1.toml", rootDir+"/sym1.toml")
+	if err != nil {
+		return "", err
+	}
+	err = os.Symlink(otherDir, rootDir+"/other")
+	if err != nil {
+		return "", err
+	}
+
 	subDir := filepath.Join(rootDir, "subDir1")
 	err = os.Mkdir(subDir, mod)
 	if err != nil {
@@ -93,7 +127,17 @@ func createDirStructure() (rootDir string, err error) {
 	if err != nil {
 		return "", err
 	}
-	return
+	err = os.Symlink(otherDir+"/sym2.toml", subSubDir+"/sym2.toml")
+	if err != nil {
+		return "", err
+	}
+
+	// tmpDir may contain symlinks itself
+	actualTmpDir, err := filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		return "", err
+	}
+	return actualTmpDir, nil
 }
 
 func TestRecursiveFilesLookup(t *testing.T) {
@@ -104,23 +148,30 @@ func TestRecursiveFilesLookup(t *testing.T) {
 		t.Errorf("Failed to create temp dirs: %s", err.Error())
 	}
 	defer os.RemoveAll(rootDir)
-	files, err := RecursiveFilesLookup(rootDir, "*toml")
+	files, err := RecursiveFilesLookup(rootDir+"/root", "*toml")
 	if err != nil {
 		t.Errorf("Failed to run recursiveFindFiles, got error: " + err.Error())
 	}
 	sort.Strings(files)
-	exceptedFiles := []string{
-		rootDir + "/" + "root.toml",
-		rootDir + "/subDir1/" + "sub1.toml",
-		rootDir + "/subDir1/" + "sub12.toml",
-		rootDir + "/subDir2/" + "sub2.toml",
-		rootDir + "/subDir2/" + "sub22.toml",
-		rootDir + "/subDir2/subSubDir/" + "subsub.toml",
-		rootDir + "/subDir2/subSubDir/" + "subsub2.toml",
+	expectedFiles := []string{
+		rootDir + "/other/" + "sym1.toml",
+		rootDir + "/other/" + "sym2.toml",
+		rootDir + "/root/" + "root.toml",
+		rootDir + "/root/subDir1/" + "sub1.toml",
+		rootDir + "/root/subDir1/" + "sub12.toml",
+		rootDir + "/root/subDir2/" + "sub2.toml",
+		rootDir + "/root/subDir2/" + "sub22.toml",
+		rootDir + "/root/subDir2/subSubDir/" + "subsub.toml",
+		rootDir + "/root/subDir2/subSubDir/" + "subsub2.toml",
 	}
-	for i, f := range exceptedFiles {
+	if len(files) != len(expectedFiles) {
+		t.Fatalf("Did not find expected files:\nExpected:\n\t%s\nFound:\n\t%s\n",
+			strings.Join(expectedFiles, "\n\t"),
+			strings.Join(files, "\n\t"))
+	}
+	for i, f := range expectedFiles {
 		if f != files[i] {
-			t.FailNow()
+			t.Fatalf("Did not find file %s\n", f)
 		}
 	}
 }


### PR DESCRIPTION
`filepath.Walk()` ignores symlinks, so evaluate any symlinks as we recurse the root path.

Closes #741