### PR TITLE
Auto Discovery of keys in tmpl file

### DIFF
--- a/backends/client.go
+++ b/backends/client.go
@@ -84,7 +84,7 @@ func New(config Config) (StoreClient, error) {
 		log.Info("DynamoDB table set to " + table)
 		return dynamodb.NewDynamoDBClient(table)
 	case "ssm":
-		return ssm.New()
+		return ssm.New(config.QueryMode)
 	}
 	return nil, errors.New("Invalid backend")
 }

--- a/backends/config.go
+++ b/backends/config.go
@@ -5,26 +5,27 @@ import (
 )
 
 type Config struct {
-	AuthToken    string     `toml:"auth_token"`
-	AuthType     string     `toml:"auth_type"`
-	Backend      string     `toml:"backend"`
-	BasicAuth    bool       `toml:"basic_auth"`
-	ClientCaKeys string     `toml:"client_cakeys"`
-	ClientCert   string     `toml:"client_cert"`
-	ClientKey    string     `toml:"client_key"`
-        ClientInsecure bool     `toml:"client_insecure"`
-	BackendNodes util.Nodes `toml:"nodes"`
-	Password     string     `toml:"password"`
-	Scheme       string     `toml:"scheme"`
-	Table        string     `toml:"table"`
-	Separator    string     `toml:"separator"`
-	Username     string     `toml:"username"`
-	AppID        string     `toml:"app_id"`
-	UserID       string     `toml:"user_id"`
-	RoleID       string     `toml:"role_id"`
-	SecretID     string     `toml:"secret_id"`
-	YAMLFile     util.Nodes `toml:"file"`
-	Filter       string     `toml:"filter"`
-	Path         string     `toml:"path"`
-	Role         string
+	AuthToken      string     `toml:"auth_token"`
+	AuthType       string     `toml:"auth_type"`
+	Backend        string     `toml:"backend"`
+	BasicAuth      bool       `toml:"basic_auth"`
+	ClientCaKeys   string     `toml:"client_cakeys"`
+	ClientCert     string     `toml:"client_cert"`
+	ClientKey      string     `toml:"client_key"`
+	ClientInsecure bool       `toml:"client_insecure"`
+	BackendNodes   util.Nodes `toml:"nodes"`
+	Password       string     `toml:"password"`
+	Scheme         string     `toml:"scheme"`
+	Table          string     `toml:"table"`
+	Separator      string     `toml:"separator"`
+	Username       string     `toml:"username"`
+	AppID          string     `toml:"app_id"`
+	UserID         string     `toml:"user_id"`
+	RoleID         string     `toml:"role_id"`
+	SecretID       string     `toml:"secret_id"`
+	YAMLFile       util.Nodes `toml:"file"`
+	Filter         string     `toml:"filter"`
+	Path           string     `toml:"path"`
+	QueryMode      string     `toml:"query_mode"`
+	Role           string
 }

--- a/backends/ssm/client.go
+++ b/backends/ssm/client.go
@@ -53,8 +53,6 @@ func (c *Client) GetValues(keys []string) (map[string]string, error) {
 		return vars, err
 	}
 
-	log.Debug("query-mode param is set to " + c.queryMode)
-
 	if c.queryMode == "byname" {
 		log.Debug("Retrieving keys by name")
 

--- a/backends/ssm/client.go
+++ b/backends/ssm/client.go
@@ -11,12 +11,15 @@ import (
 )
 
 type Client struct {
-	client *ssm.SSM
+	client    *ssm.SSM
+	queryMode string
 }
 
-func New() (*Client, error) {
+func New(queryMode string) (*Client, error) {
 	// Create a session to share configuration, and load external configuration.
-	sess := session.Must(session.NewSession())
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
 
 	// Fail early, if no credentials can be found
 	_, err := sess.Config.Credentials.Get()
@@ -37,31 +40,56 @@ func New() (*Client, error) {
 
 	// Create the service's client with the session.
 	svc := ssm.New(sess, c)
-	return &Client{svc}, nil
+	return &Client{svc, queryMode}, nil
 }
 
 // GetValues retrieves the values for the given keys from AWS SSM Parameter Store
 func (c *Client) GetValues(keys []string) (map[string]string, error) {
 	vars := make(map[string]string)
 	var err error
-	for _, key := range keys {
-		log.Debug("Processing key=%s", key)
-		var resp map[string]string
-		resp, err = c.getParametersWithPrefix(key)
+	var resp map[string]string
+
+	if len(keys) <= 0 {
+		return vars, err
+	}
+
+	log.Debug("query-mode param is set to " + c.queryMode)
+
+	if c.queryMode == "byname" {
+		log.Debug("Retrieving keys by name")
+
+		resp, err = c.getParameters(keys)
+
 		if err != nil {
 			return vars, err
 		}
-		if len(resp) == 0 {
-			resp, err = c.getParameter(key)
-			if err != nil && err.(awserr.Error).Code() != ssm.ErrCodeParameterNotFound {
-				return vars, err
-			}
-		}
+
 		for k, v := range resp {
 			vars[k] = v
 		}
+	} else {
+		log.Debug("Retrieving keys by path")
+
+		for _, key := range keys {
+			log.Debug("Processing key=%s", key)
+			var resp map[string]string
+			resp, err = c.getParametersWithPrefix(key)
+			if err != nil {
+				return vars, err
+			}
+			if len(resp) == 0 {
+				resp, err = c.getParameter(key)
+				if err != nil && err.(awserr.Error).Code() != ssm.ErrCodeParameterNotFound {
+					return vars, err
+				}
+			}
+			for k, v := range resp {
+				vars[k] = v
+			}
+		}
 	}
-	return vars, nil
+
+	return vars, err
 }
 
 func (c *Client) getParametersWithPrefix(prefix string) (map[string]string, error) {
@@ -93,6 +121,22 @@ func (c *Client) getParameter(name string) (map[string]string, error) {
 		return parameters, err
 	}
 	parameters[*resp.Parameter.Name] = *resp.Parameter.Value
+	return parameters, nil
+}
+
+func (c *Client) getParameters(names []string) (map[string]string, error) {
+	parameters := make(map[string]string)
+	params := &ssm.GetParametersInput{
+		Names:          aws.StringSlice(names),
+		WithDecryption: aws.Bool(true),
+	}
+	resp, err := c.client.GetParameters(params)
+	if err != nil {
+		return parameters, err
+	}
+	for _, p := range resp.Parameters {
+		parameters[*p.Name] = *p.Value
+	}
 	return parameters, nil
 }
 

--- a/config.go
+++ b/config.go
@@ -44,7 +44,7 @@ func init() {
 	flag.StringVar(&config.ClientCaKeys, "client-ca-keys", "", "client ca keys")
 	flag.StringVar(&config.ClientCert, "client-cert", "", "the client cert")
 	flag.StringVar(&config.ClientKey, "client-key", "", "the client key")
-        flag.BoolVar(&config.ClientInsecure, "client-insecure", false, "Allow connections to SSL sites without certs (only used with -backend=etcd)")
+	flag.BoolVar(&config.ClientInsecure, "client-insecure", false, "Allow connections to SSL sites without certs (only used with -backend=etcd)")
 	flag.StringVar(&config.ConfDir, "confdir", "/etc/confd", "confd conf directory")
 	flag.StringVar(&config.ConfigFile, "config-file", "/etc/confd/confd.toml", "the confd config file")
 	flag.Var(&config.YAMLFile, "file", "the YAML file to watch for changes (only used with -backend=file)")
@@ -73,6 +73,7 @@ func init() {
 	flag.StringVar(&config.Username, "username", "", "the username to authenticate as (only used with vault and etcd backends)")
 	flag.StringVar(&config.Password, "password", "", "the password to authenticate with (only used with vault and etcd backends)")
 	flag.BoolVar(&config.Watch, "watch", false, "enable watch support")
+	flag.StringVar(&config.QueryMode, "query-mode", "", "SSM retrieval strategy: by path prefix (default), or by name (-query-mode=byname) (only used with -backend=ssm)")
 }
 
 // initConfig initializes the confd configuration by first setting defaults,

--- a/docs/command-line-flags.md
+++ b/docs/command-line-flags.md
@@ -76,6 +76,8 @@ Usage of confd:
       print version and exit
   -watch
       enable watch support
+  -query-mode
+      SSM retrieval strategy: by path prefix (default), or by name (-query-mode=byname) (only used with -backend=ssm)
 ```
 
 > The -scheme flag is only used to set the URL scheme for nodes retrieved from DNS SRV records.

--- a/resource/template/keysCache.go
+++ b/resource/template/keysCache.go
@@ -1,0 +1,66 @@
+package template
+
+type KeysCache struct {
+	FuncMap map[string]interface{}
+	Keys    []string
+}
+
+func NewKeysCache() *KeysCache {
+	k := &KeysCache{}
+	k.FuncMap = map[string]interface{}{
+		"exists": k.Exists,
+		"ls":     k.List,
+		"lsdir":  k.ListDir,
+		"get":    k.Get,
+		"gets":   k.GetAll,
+		"getv":   k.GetValue,
+		"getvs":  k.GetAllValues,
+	}
+	return k
+}
+
+func (k *KeysCache) CacheKey(key string) {
+	k.Keys = append(k.Keys, key)
+}
+
+func (k *KeysCache) Del(key string) {
+	k.CacheKey(key)
+}
+
+func (k *KeysCache) Exists(key string) bool {
+	k.CacheKey(key)
+	return false
+}
+
+func (k *KeysCache) Get(key string) (map[string]string, error) {
+	k.CacheKey(key)
+	return nil, nil
+}
+
+func (k *KeysCache) GetValue(key string, v ...string) (string, error) {
+	k.CacheKey(key)
+	return "", nil
+}
+
+func (k *KeysCache) GetAll(pattern string) (map[string]string, error) {
+	return nil, nil
+}
+
+func (k *KeysCache) GetAllValues(pattern string) ([]string, error) {
+	return nil, nil
+}
+
+func (k *KeysCache) List(filePath string) []string {
+	return nil
+}
+
+func (k *KeysCache) ListDir(filePath string) []string {
+	return nil
+}
+
+func (k *KeysCache) Set(key string, value string) {
+	k.CacheKey(key)
+}
+
+func (k *KeysCache) Purge() {
+}


### PR DESCRIPTION
In the current confd version you must specify the keys in the toml file.
This is a repetition of the DRY principle, as they are already declared in the tmpl file.
When using SSM as a backend, you can specify the keys as = [""], but that will retrieve all the keys from SSM, which causes a major performance hit.

Instead of repeating the keys in the toml file, AutoDiscoverKeys flag allows to read the tmpl file and fetch only the relevant keys.

Add AutoDiscoverKeys flag that retrieves from Store only the referenced keys in the tmpl file.
Add SSM improvement to allow query by specific key names, instead of by path prefix.