### PR TITLE
[SSM] Added support for custom endpoints

### DIFF
--- a/backends/ssm/client.go
+++ b/backends/ssm/client.go
@@ -25,13 +25,20 @@ func New() (*Client, error) {
 	}
 
 	var c *aws.Config
-	if os.Getenv("SSM_LOCAL") != "" {
-		log.Debug("SSM_LOCAL is set")
-		endpoint := "http://localhost:8001"
+
+	if os.Getenv("SSM_CUSTOM_ENDPOINT") != "" {
+		log.Debug("SSM_CUSTOM_ENDPOINT is set")
+		endpoint := os.Getenv("SSM_CUSTOM_ENDPOINT")
 		c = &aws.Config{
 			Endpoint: &endpoint,
 		}
-	} else {
+	} else if os.Getenv("SSM_LOCAL") != "" {
+           		log.Debug("SSM_LOCAL is set")
+           		endpoint := "http://localhost:8001"
+           		c = &aws.Config{
+           			Endpoint: &endpoint,
+           		}
+    } else {
 		c = nil
 	}
 


### PR DESCRIPTION
Hello,

I'm using localstack in my environment and I needed to specify a different URL for SSM. The hardcoded url for local wasn't OK for me, cause it's running in docker. I did it more flexible by accepting a custom endpoint.

Hopefully this is useful for someone else.

Thanks.