### PR TITLE
Add -sync-first flag to render template before processing with interval or watching

### DIFF
--- a/confd.go
+++ b/confd.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"runtime"
 	"syscall"
+	"time"
 
 	"github.com/kelseyhightower/confd/backends"
 	"github.com/kelseyhightower/confd/log"
@@ -36,6 +37,17 @@ func main() {
 			log.Fatal(err.Error())
 		}
 		os.Exit(0)
+	}
+
+	if config.SyncFirst {
+		for {
+			if err := template.Process(config.TemplateConfig); err != nil {
+				log.Error(err.Error())
+				time.Sleep(5 * time.Second)
+			} else {
+				break
+			}
+		}
 	}
 
 	stopChan := make(chan bool)

--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	PrintVersion bool
 	ConfigFile   string
 	OneTime      bool
+	SyncFirst    bool
 }
 
 var config Config
@@ -70,6 +71,7 @@ func init() {
 	flag.StringVar(&config.Username, "username", "", "the username to authenticate as (only used with vault and etcd backends)")
 	flag.StringVar(&config.Password, "password", "", "the password to authenticate with (only used with vault and etcd backends)")
 	flag.BoolVar(&config.Watch, "watch", false, "enable watch support")
+	flag.BoolVar(&config.SyncFirst, "sync-first", false, "sync template first")
 }
 
 // initConfig initializes the confd configuration by first setting defaults,


### PR DESCRIPTION
If we are using Zookepper and znodes are not initialized yet, confd start watching nodes as they are created but do not render template. As this process has race conditions it would be fine to introduce the option to render template as startup and then continue to processing.